### PR TITLE
Allow generic data to be registered for pipe and provider

### DIFF
--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClientIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClientIntegrationSpec.groovy
@@ -15,8 +15,7 @@ import java.time.ZonedDateTime
 class InternalHttpPipeClientIntegrationSpec extends Specification {
 
     @Shared @AutoCleanup ErsatzServer server
-    @Shared @AutoCleanup ApplicationContext context
-
+    @Shared @AutoCleanup("stop") ApplicationContext context
 
     PipeLoadBalancer loadBalancer
     InternalHttpPipeClient client

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo
 class PipeLoadBalancerIntegrationSpec extends Specification {
 
     @AutoCleanup ErsatzServer serverA
-    @AutoCleanup ApplicationContext context
+    @AutoCleanup("stop") ApplicationContext context
 
     HttpPipeClient client
     PipeLoadBalancer loadBalancer

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/AuthenticatePipeReadFilterSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/AuthenticatePipeReadFilterSpec.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
 class AuthenticatePipeReadFilterSpec extends Specification {
 
     @Shared @AutoCleanup ErsatzServer server
-    @Shared @AutoCleanup ApplicationContext context
+    @Shared @AutoCleanup("stop") ApplicationContext context
 
     InternalHttpPipeClient client
 

--- a/pipe-http-server-cloud/src/test/groovy/NodeRegistryControllerSpec.groovy
+++ b/pipe-http-server-cloud/src/test/groovy/NodeRegistryControllerSpec.groovy
@@ -24,8 +24,8 @@ class NodeRegistryControllerSpec extends Specification {
     static final String RUNSCOPE_USERNAME = "runscope-username"
     static final String RUNSCOPE_PASSWORD = "runscope-password"
 
-    @Shared @AutoCleanup ApplicationContext context
-    @Shared @AutoCleanup EmbeddedServer server
+    @Shared @AutoCleanup("stop") ApplicationContext context
+    @Shared @AutoCleanup("stop") EmbeddedServer server
 
     void setup() {
         context = ApplicationContext

--- a/pipe-http-server-cloud/src/test/groovy/PipeCloudServerSpec.groovy
+++ b/pipe-http-server-cloud/src/test/groovy/PipeCloudServerSpec.groovy
@@ -22,14 +22,9 @@ class PipeCloudServerSpec extends Specification {
     static LocalDateTime time = LocalDateTime.parse("2018-12-20T15:13:01")
 
     // Starts real PostgreSQL database, takes some time to create it and clean it up.
-    @Shared @ClassRule
-    SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance()
-
-    @AutoCleanup
-    Sql sql
-
-    @AutoCleanup
-    ApplicationContext context
+    @Shared @ClassRule SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance()
+    @AutoCleanup Sql sql
+    @AutoCleanup("stop") ApplicationContext context
 
     DataSource dataSource
 
@@ -119,14 +114,5 @@ class PipeCloudServerSpec extends Specification {
             message.getTags(),
             message.getData()
         )
-    }
-
-    @Ignore
-    def "starts an demo app" (){
-        setup:
-        println "Server is running on port $RestAssured.port"
-
-        expect:
-        Thread.sleep(100000000000)
     }
 }

--- a/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadAuthenticationProviderIntegrationSpec.groovy
+++ b/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadAuthenticationProviderIntegrationSpec.groovy
@@ -26,8 +26,8 @@ class PipeReadAuthenticationProviderIntegrationSpec extends Specification {
 
     static InMemoryStorage storage = new InMemoryStorage(10, RETRY_AFTER_SECONDS)
 
-    @Shared @AutoCleanup ApplicationContext context
-    @Shared @AutoCleanup EmbeddedServer server
+    @Shared @AutoCleanup("stop") ApplicationContext context
+    @Shared @AutoCleanup("stop") EmbeddedServer server
 
     void setupSpec() {
         context = ApplicationContext

--- a/pipe-http-server/src/test/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerSpec.groovy
+++ b/pipe-http-server/src/test/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerSpec.groovy
@@ -23,20 +23,14 @@ class PipeReadControllerSpec extends Specification {
     static String type = "type1"
     static int RETRY_AFTER_SECONDS = 600
 
-    @Shared
-    InMemoryStorage storage = new InMemoryStorage(10, RETRY_AFTER_SECONDS)
-    @Shared
-    @AutoCleanup
-    ApplicationContext context
-    @Shared
-    @AutoCleanup
-    EmbeddedServer server
+    @Shared InMemoryStorage storage = new InMemoryStorage(10, RETRY_AFTER_SECONDS)
+    @Shared @AutoCleanup("stop") ApplicationContext context
+    @Shared @AutoCleanup("stop") EmbeddedServer server
 
     // overloads of settings for this test
-    @Shared
-        propertyOverloads = [
-            "pipe.http.server.read.response-size-limit-in-bytes": "200"
-        ]
+    @Shared propertyOverloads = [
+        "pipe.http.server.read.response-size-limit-in-bytes": "200"
+    ]
 
     void setupSpec() {
         // There is nicer way in the works: https://github.com/micronaut-projects/micronaut-test

--- a/pipe-http-server/src/test/groovy/com/tesco/aqueduct/pipe/http/StatusControllerSpec.groovy
+++ b/pipe-http-server/src/test/groovy/com/tesco/aqueduct/pipe/http/StatusControllerSpec.groovy
@@ -18,9 +18,8 @@ class StatusControllerSpec extends Specification {
     static final String RUNSCOPE_USERNAME = "runscope-username"
     static final String RUNSCOPE_PASSWORD = "runscope-password"
 
-    @Shared @AutoCleanup ApplicationContext context
-    @Shared @AutoCleanup EmbeddedServer server
-
+    @Shared @AutoCleanup("stop") ApplicationContext context
+    @Shared @AutoCleanup("stop") EmbeddedServer server
 
     void setupSpec() {
         context = ApplicationContext

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/SelfRegistrationTaskSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/SelfRegistrationTaskSpec.groovy
@@ -27,7 +27,7 @@ class SelfRegistrationTaskSpec extends Specification {
         def startedLatch = new CountDownLatch(1)
 
         given: "a registry client"
-        def registryClient = new SelfRegistrationTask(upstreamClient, registryHitList, { MY_NODE }, {}, CLOUD_PIPE)
+        def registryClient = new SelfRegistrationTask(upstreamClient, registryHitList, { MY_NODE }, CLOUD_PIPE)
 
         when: "register() is called"
         registryClient.register()
@@ -42,7 +42,7 @@ class SelfRegistrationTaskSpec extends Specification {
 
     def 'check registryHitList defaults to cloud pipe if register call fails'() {
         given: "a registry client"
-        def registryClient = new SelfRegistrationTask(upstreamClient, registryHitList, { MY_NODE }, {}, CLOUD_PIPE)
+        def registryClient = new SelfRegistrationTask(upstreamClient, registryHitList, { MY_NODE }, CLOUD_PIPE)
 
         when: "register() is called"
         registryClient.register()

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/Node.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/Node.java
@@ -50,7 +50,7 @@ public class Node {
     /**
      * The last ACKed offset from the Provider.
      *
-     * Reported by older versions of magic pipe / provider.
+     * Reported by older versions of aqueduct pipe / provider.
      */
     @Deprecated
     private final long providerLastAckOffset;
@@ -58,7 +58,7 @@ public class Node {
     /**
      * Tracks the time that the last message was ACKed by a client.
      *
-     * Reported by older versions of magic pipe / provider.
+     * Reported by older versions of aqueduct pipe / provider.
      */
     @Deprecated
     private final ZonedDateTime providerLastAckTime;

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/Node.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/Node.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Builder(toBuilder = true)
 @Data
@@ -47,19 +48,30 @@ public class Node {
     private final ZonedDateTime lastSeen;
 
     /**
-     * The time at which the latest offset was received.
+     * The last ACKed offset from the Provider.
+     *
+     * Reported by older versions of magic pipe / provider.
      */
-    private final ZonedDateTime latestArrivalTime;
-
-    /**
-     * The last ACKed offset from the Provider
-     */
+    @Deprecated
     private final long providerLastAckOffset;
 
     /**
      * Tracks the time that the last message was ACKed by a client.
+     *
+     * Reported by older versions of magic pipe / provider.
      */
+    @Deprecated
     private final ZonedDateTime providerLastAckTime;
+
+    /**
+     * Fields populated by pipe
+     */
+    private final Map<String, String> pipe;
+
+    /**
+     * Fields populated by provider
+     */
+    private final Map<String, String> provider;
 
     public String getId() {
         if (group == null) {

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/RegistryLogger.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/RegistryLogger.java
@@ -54,9 +54,20 @@ public class RegistryLogger {
                         .collect(Collectors.joining(","))
         );
         fields.put("lastSeen", String.valueOf(node.getLastSeen()));
-        fields.put("latestArrivalTime", String.valueOf(node.getLatestArrivalTime()));
         fields.put("providerLastAckOffset", String.valueOf(node.getProviderLastAckOffset()));
         fields.put("providerLastAckTime", String.valueOf(node.getProviderLastAckTime()));
+
+        if(node.getPipe() != null) {
+            node.getPipe().entrySet().forEach(e ->
+                fields.put("pipe." + e.getKey(), e.getValue())
+            );
+        }
+
+        if(node.getProvider() != null) {
+            node.getProvider().entrySet().forEach(e ->
+                fields.put("provider." + e.getKey(), e.getValue())
+            );
+        }
 
         return new RegistryLogger(this, fields);
     }

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/NodeRegistrySpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/NodeRegistrySpec.groovy
@@ -300,7 +300,6 @@ class NodeRegistrySpec extends Specification {
             .following(following)
             .lastSeen(created)
             .requestedToFollow(requestedToFollow)
-            .latestArrivalTime(now)
             .providerLastAckOffset(offset-1)
             .providerLastAckTime(now)
             .build()

--- a/registry-ui/src/main/resources/ui/demoGraph.js
+++ b/registry-ui/src/main/resources/ui/demoGraph.js
@@ -19,7 +19,14 @@ let demoGraph = {
             "http://demo"
         ],
         "lastSeen": "2019-02-07T22:32:27.15Z",
-        "id": "6735|http://1.1.1.0"
+        "id": "6735|http://1.1.1.0",
+        "provider": {
+            "lastOffsetSent": 110,
+            "lastAckedOffset": 109,
+            "latestMessageLatency": 10,
+            "timeOfLastSent": "2019-05-21T16:47:42.815Z",
+            "timeOfLastAck": "2019-05-21T16:47:40.815Z"
+        }
     },
     {
         "group": "6735",
@@ -35,7 +42,14 @@ let demoGraph = {
             "http://demo"
         ],
         "lastSeen": "2019-02-07T22:32:27.165Z",
-        "id": "6735|http://1.1.1.1"
+        "id": "6735|http://1.1.1.1",
+        "provider": {
+            "lastOffsetSent": 108,
+            "lastAckedOffset": 108,
+            "latestMessageLatency": 10,
+            "timeOfLastSent": "2019-05-21T16:47:42.815Z",
+            "timeOfLastAck": "2019-05-21T16:47:40.815Z"
+        }
     },
     {
         "group": "6735",
@@ -51,7 +65,14 @@ let demoGraph = {
             "http://demo"
         ],
         "lastSeen": "2019-02-07T22:32:27.172Z",
-        "id": "6735|http://1.1.1.2"
+        "id": "6735|http://1.1.1.2",
+        "provider": {
+            "lastOffsetSent": 104,
+            "lastAckedOffset": 104,
+            "latestMessageLatency": 10,
+            "timeOfLastSent": "2019-05-21T16:47:42.815Z",
+            "timeOfLastAck": "2019-05-21T16:47:40.815Z"
+        }
     },
     {
         "group": "6735",

--- a/registry-ui/src/main/resources/ui/index.html
+++ b/registry-ui/src/main/resources/ui/index.html
@@ -34,6 +34,19 @@
         <option value="providerLastAckOffset">Last Ack Offset</option>
         <option value="providerLastAckTime">Last Ack time</option>
         <option value="status">Status</option>
+
+        <!-- Legacy fields -->
+        <option value="providerLastAckOffset">Legacy Last Ack Offset</option>
+        <option value="providerLastAckTime">Legacy Last Ack time</option>
+
+        <!-- New fields -->
+        <option value="provider.ip">Provider Ip</option>
+        <option value="provider.id">Provider Id</option>
+        <option value="provider.lastAckedOffset">Provider Last Ack Offset</option>
+        <option value="provider.timeOfLastAck">Provider Last Ack time</option>
+        <option value="provider.lastOffsetSent">Provider Last Sent Offset</option>
+        <option value="provider.timeOfLastSent">Provider Last Sent time</option>
+        <option value="provider.latestMessageLatency">Provider Last Message Latency</option>
     </select>
 
     <select id="styleSelector"></select>
@@ -62,6 +75,20 @@
     -->
     
     <script id="js"> 
+        function normalise(str){
+            if(str) {
+                return str
+                    // add space before each group of upper case letters
+                    .replace(/([A-Z]+)/g, ' $1')
+                    .toLowerCase()
+                    // uppercase the first character only
+                    .replace(/^./, str => str.toUpperCase())
+                ;
+            } else {
+                return null;
+            }
+        }
+
         $("#svg-canvas")
             .attr("width", window.innerWidth)
             .attr("height", window.innerHeight);
@@ -119,6 +146,20 @@
                 requestedToFollow = data.requestedToFollow.join('<br>')
             }
             
+            var rows = ""
+            if(data.provider) {
+                rows = Object.keys(data.provider)
+                    .map(key => `<tr><td>${normalise(key)}</td><td>${data.provider[key]}</td></tr>`)
+                    .join("\n");
+                rows += "\n"
+            }
+            if(data.pipe) {
+                rows += Object.keys(data.pipe)
+                    .map(key => `<tr><td>${normalise(key)}</td><td>${data.pipe[key]}</td></tr>`)
+                    .join("\n");
+                rows += "\n"
+            }
+
             return `
             ${data.localUrl}
             <table>
@@ -142,6 +183,8 @@
                     <td>Requested to following</td>
                     <td>${requestedToFollow}</td>
                 </tr>
+
+                <!-- Legacy provider data -->
                 <tr>
                     <td>Last Ack Offset</td>
                     <td>${data.providerLastAckOffset}</td>
@@ -150,6 +193,9 @@
                     <td>Last Ack time</td>
                     <td>${data.providerLastAckTime}</td>
                 </tr>
+
+                <!-- New provider data -->
+                ${rows}
             </table>
             `
         };
@@ -273,7 +319,15 @@
 
         let getLabelProvider = () => {
             let property = $("#nameSelector").val();
-            return (node) => node[property];
+            return (node) => {
+                try {
+                    console.log("property " + property);
+                    console.log(property.split('.').reduce((a, b) => a[b], node));
+                    return property.split('.').reduce((a, b) => a[b], node);
+                } catch (e) {
+                    return "";
+                }
+            }
         }
 
         let fetchSummary = () => {

--- a/registry-ui/src/test/groovy/com/tesco/aqueduct/pipe/http/PageSpec.groovy
+++ b/registry-ui/src/test/groovy/com/tesco/aqueduct/pipe/http/PageSpec.groovy
@@ -9,12 +9,9 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class PageSpec extends Specification {
-    @Shared
-    @AutoCleanup
-    ApplicationContext context
-    @Shared
-    @AutoCleanup
-    EmbeddedServer server
+
+    @Shared @AutoCleanup("stop") ApplicationContext context
+    @Shared @AutoCleanup("stop") EmbeddedServer server
 
     void setupSpec() {
         context = ApplicationContext


### PR DESCRIPTION
Using maps to support metrics being send to registry without needing to explicitly mention them.
Allows to add new values from provider faster.
UI is still hardcoded.