### PR TITLE
Compaction fix

### DIFF
--- a/deployment/jenkins/Jenkinsfile
+++ b/deployment/jenkins/Jenkinsfile
@@ -95,11 +95,7 @@ ansiColor('xterm') {
                 junit '**/build/test-results/test/*.xml'
             }
             stage('Publish Coverage Report') {
-                try {
-                    sh "#!/bin/sh -e\n./gradlew jacocoRootReport -PmavenUser=$nexusUsername -PmavenPassword=$nexusPassword"
-                } finally {
-                    jacoco buildOverBuild: true, changeBuildStatus: true, deltaBranchCoverage: '50', deltaClassCoverage: '50', deltaComplexityCoverage: '50', deltaInstructionCoverage: '50', deltaLineCoverage: '50', deltaMethodCoverage: '50', exclusionPattern: '**/*Spec.class'
-                }
+                jacoco buildOverBuild: true, changeBuildStatus: true, deltaBranchCoverage: '50', deltaClassCoverage: '50', deltaComplexityCoverage: '50', deltaInstructionCoverage: '50', deltaLineCoverage: '50', deltaMethodCoverage: '50', exclusionPattern: '**/*Spec.class'
                 echo "RESULT: ${currentBuild.result}"
             }
             stage('Docker build and Scan') {

--- a/deployment/jenkins/Jenkinsfile
+++ b/deployment/jenkins/Jenkinsfile
@@ -100,6 +100,7 @@ ansiColor('xterm') {
                 } finally {
                     jacoco buildOverBuild: true, changeBuildStatus: true, deltaBranchCoverage: '50', deltaClassCoverage: '50', deltaComplexityCoverage: '50', deltaInstructionCoverage: '50', deltaLineCoverage: '50', deltaMethodCoverage: '50', exclusionPattern: '**/*Spec.class'
                 }
+                echo "RESULT: ${currentBuild.result}"
             }
             stage('Docker build and Scan') {
                 container('docker') {

--- a/deployment/jenkins/Jenkinsfile
+++ b/deployment/jenkins/Jenkinsfile
@@ -75,12 +75,30 @@ ansiColor('xterm') {
                     }
                 }
             )
-            stage('Unit & Integration Test') {
+            stage('Unit Test') {
                 try {
-                    sh "./gradlew test integration jacocoRootReport"
-                } finally {
+                    sh "./gradlew test"
+                } catch(err) {
                     junit '**/build/test-results/test/*.xml'
-                    jacoco buildOverBuild: true, deltaClassCoverage: '5', deltaLineCoverage: '5', deltaMethodCoverage: '5', exclusionPattern: '**/*Spec.class', execPattern: '**/jacocoMerge.exec'
+                    throw err
+                }
+            }
+            stage('Integration Test') {
+                try {
+                    sh "./gradlew integration"
+                } catch(err) {
+                    junit '**/build/test-results/test/*.xml'
+                    throw err
+                }
+            }
+            stage('Publish Test Report') {
+                junit '**/build/test-results/test/*.xml'
+            }
+            stage('Publish Coverage Report') {
+                try {
+                    sh "#!/bin/sh -e\n./gradlew jacocoRootReport -PmavenUser=$nexusUsername -PmavenPassword=$nexusPassword"
+                } finally {
+                    jacoco buildOverBuild: true, exclusionPattern: '**/*Spec.class', execPattern: '**/jacocoMerge.exec'
                 }
             }
             stage('Docker build and Scan') {

--- a/deployment/jenkins/Jenkinsfile
+++ b/deployment/jenkins/Jenkinsfile
@@ -98,7 +98,7 @@ ansiColor('xterm') {
                 try {
                     sh "#!/bin/sh -e\n./gradlew jacocoRootReport -PmavenUser=$nexusUsername -PmavenPassword=$nexusPassword"
                 } finally {
-                    jacoco buildOverBuild: true, changeBuildStatus: true, exclusionPattern: '**/*Spec.class', execPattern: '**/jacocoMerge.exec'
+                    jacoco buildOverBuild: true, changeBuildStatus: true, deltaBranchCoverage: '50', deltaClassCoverage: '50', deltaComplexityCoverage: '50', deltaInstructionCoverage: '50', deltaLineCoverage: '50', deltaMethodCoverage: '50', exclusionPattern: '**/*Spec.class'
                 }
             }
             stage('Docker build and Scan') {

--- a/deployment/jenkins/Jenkinsfile
+++ b/deployment/jenkins/Jenkinsfile
@@ -98,7 +98,7 @@ ansiColor('xterm') {
                 try {
                     sh "#!/bin/sh -e\n./gradlew jacocoRootReport -PmavenUser=$nexusUsername -PmavenPassword=$nexusPassword"
                 } finally {
-                    jacoco buildOverBuild: true, exclusionPattern: '**/*Spec.class', execPattern: '**/jacocoMerge.exec'
+                    jacoco buildOverBuild: true, changeBuildStatus: true, exclusionPattern: '**/*Spec.class', execPattern: '**/jacocoMerge.exec'
                 }
             }
             stage('Docker build and Scan') {

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/EventQueries.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/EventQueries.java
@@ -20,7 +20,7 @@ final class EventQueries {
             "INSERT INTO EVENT (msg_offset, msg_key, content_type, type, created_utc, data, event_size) VALUES (?,?,?,?,?,?,?);";
 
     static final String COMPACT =
-            "DELETE FROM EVENT WHERE created_utc <= ? AND msg_offset NOT IN (SELECT max(msg_offset) FROM EVENT GROUP BY msg_key);";
+            "DELETE FROM EVENT WHERE created_utc <= ? AND msg_offset NOT IN (SELECT max(msg_offset) FROM EVENT WHERE created_utc <= ? GROUP BY msg_key);";
 
     static String getReadEvent(final int typesCount, final long maxBatchSize) {
         final StringBuilder queryBuilder = new StringBuilder(

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
@@ -154,8 +154,9 @@ public class SQLiteStorage implements MessageStorage {
         // We may want a interface - Compactable - for this method signature
         try (Connection connection = dataSource.getConnection();
             PreparedStatement statement = connection.prepareStatement(EventQueries.COMPACT)) {
-            statement.setTimestamp(1, Timestamp.valueOf(zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()));
-            statement.setTimestamp(2, Timestamp.valueOf(zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()));
+            Timestamp threshold = Timestamp.valueOf(zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime());
+            statement.setTimestamp(1, threshold);
+            statement.setTimestamp(2, threshold);
             final int rowsAffected = statement.executeUpdate();
             LOG.info("compaction", "compacted " + rowsAffected + " rows");
         } catch (SQLException e) {

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
@@ -155,6 +155,7 @@ public class SQLiteStorage implements MessageStorage {
         try (Connection connection = dataSource.getConnection();
             PreparedStatement statement = connection.prepareStatement(EventQueries.COMPACT)) {
             statement.setTimestamp(1, Timestamp.valueOf(zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()));
+            statement.setTimestamp(2, Timestamp.valueOf(zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()));
             final int rowsAffected = statement.executeUpdate();
             LOG.info("compaction", "compacted " + rowsAffected + " rows");
         } catch (SQLException e) {


### PR DESCRIPTION
Small changes:
- Compaction threshold considered when looking for the unique set of keys now, rather than all keys as before. Changes in both Postgres and sqlite for this.
- Tests changed to reflect this for both storage implementations
- There was a lack of tests in Postgres around compaction, so some have been added.
- Small refactoring of queries.