### PR TITLE
Logging Less

### DIFF
--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/PipeLoadBalancer.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/PipeLoadBalancer.java
@@ -123,7 +123,7 @@ public class PipeLoadBalancer implements LoadBalancer, RegistryHitList {
             .onErrorComplete();
     }
 
-    private void instanceIsUp(final PathRespectingPipeInstance instance, boolean isUp) {
+    private void instanceIsUp(final PathRespectingPipeInstance instance, final boolean isUp) {
         LOG.info("healthcheck.success", instance.getUrl().toString());
         instance.setUp(isUp);
     }

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/PipeLoadBalancer.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/PipeLoadBalancer.java
@@ -96,11 +96,12 @@ public class PipeLoadBalancer implements LoadBalancer, RegistryHitList {
     public void checkState() {
         LOG.info("healthcheck urls", servicesString());
         fromIterable(services)
-            .flatMapCompletable(instance -> checkState(new DefaultHttpClient(instance.getUrl(), configuration), instance))
+            .flatMapCompletable(this::checkState)
             .blockingAwait();
     }
 
-    private Completable checkState(final RxHttpClient client, final PathRespectingPipeInstance instance) {
+    private Completable checkState(final PathRespectingPipeInstance instance) {
+        final RxHttpClient client = new DefaultHttpClient(instance.getUrl(), configuration);
         final String urlWithPath = UriBuilder.of(instance.getURI()).path("/pipe/_status").build().toString();
         return client.retrieve(urlWithPath)
             // if got response, then it's a true

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
@@ -159,6 +159,9 @@ class PipeLoadBalancerSpec extends Specification {
 
         then:
         noExceptionThrown()
+
+        and:
+        !serviceInstance.isUp()
     }
 
     ErsatzServer serverWithPipeStatus(int status) {

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
@@ -147,15 +147,10 @@ class PipeLoadBalancerSpec extends Specification {
 
     def "RxClient errors are not rethrown"() {
         given: "client throwing errors"
-        def serviceInstance = new PathRespectingPipeInstance(new URL("http://localhost"), true)
-        RxHttpClient client = Mock()
-        client.retrieve(_) >> Flowable.error(new RuntimeException())
-        client.close() >> {
-            throw new RuntimeException()
-        }
+        def serviceInstance = new PathRespectingPipeInstance(new URL("http://not.a.url"), true)
 
         when: "we check the state"
-        loadBalancer.checkState(serviceInstance, client).blockingAwait()
+        loadBalancer.checkState(serviceInstance).blockingAwait()
 
         then:
         noExceptionThrown()

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/PipeLoadBalancerSpec.groovy
@@ -155,7 +155,7 @@ class PipeLoadBalancerSpec extends Specification {
         }
 
         when: "we check the state"
-        loadBalancer.checkState(client, serviceInstance).blockingAwait()
+        loadBalancer.checkState(serviceInstance, client).blockingAwait()
 
         then:
         noExceptionThrown()

--- a/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -302,11 +302,11 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         3          | 3       | 1       | "3 tills"
         10         | 3       | 1       | "3 tills 10 calls"
         100        | 3       | 2       | "3 tills 100 calls"
-        500        | 3       | 14      | "3 tills 500 calls"
+        500        | 3       | 20      | "3 tills 500 calls"
         10         | 10      | 1       | "10 tills"
         50         | 50      | 3       | "50 tills"
         100        | 100     | 5       | "100 tills"
-        250        | 250     | 10       | "250 tills"
+        250        | 250     | 10      | "250 tills"
     }
 
     def "node registry can handle concurrent multiple group requests (10 stores with 50 tills each)"() {


### PR DESCRIPTION
When healthcheck fails, it currently logs a stacktrace which fills the logs up pretty quickly (particularly in PPE where tills can't necessarily speak to their parent). The change here is to log only the error message.