### PR TITLE
Remove unused micronaut dependency that may be causing DumpMetrics issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ subprojects {
 
                 compile 'io.micronaut:micronaut-security'
                 compile 'io.micronaut:micronaut-security-jwt'
-                compile 'io.micronaut:micronaut-validation'
                 compile "io.micronaut:micronaut-management"
                 compile 'io.micronaut.configuration:micronaut-micrometer-core'
 


### PR DESCRIPTION
Due to timing of issue, its likely that some change made in [this PR](https://github.com/Tesco/aqueduct-core/commit/9a82a978d23a8f66b307c25c7e7be33f63bbc816) caused the issue.