### PR TITLE
Node registry sorts by node status

### DIFF
--- a/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -189,6 +189,13 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         followers[4].getLocalUrl() == url2
         followers[5].getLocalUrl() == url6
 
+        followers[0].status == "following"
+        followers[1].status == "following"
+        followers[2].status == "following"
+        followers[3].status == "offline"
+        followers[4].status == "offline"
+        followers[5].status == "offline"
+
         followers[0].requestedToFollow == [cloudURL]
         followers[1].requestedToFollow == [url3, cloudURL]
         followers[2].requestedToFollow == [url3, cloudURL]

--- a/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-core/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -98,6 +98,105 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         followers.size() == 1
     }
 
+    def "registry marks nodes offline and sorts based on status"() {
+        given: "a registry with a short offline delta"
+        registry = new PostgreSQLNodeRegistry(dataSource, cloudURL, Duration.ofSeconds(5))
+
+        and: "6 nodes"
+        long offset = 12345
+
+        URL url1 = new URL("http://1.1.1.1")
+        Node node1 = Node.builder()
+            .group("group")
+            .localUrl(url1)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        URL url2 = new URL("http://2.2.2.2")
+        Node node2 = Node.builder()
+            .group("group")
+            .localUrl(url2)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        URL url3 = new URL("http://3.3.3.3")
+        Node node3 = Node.builder()
+            .group("group")
+            .localUrl(url3)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        URL url4= new URL("http://4.4.4.4")
+        Node node4 = Node.builder()
+            .group("group")
+            .localUrl(url4)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        URL url5 = new URL("http://5.5.5.5")
+        Node node5 = Node.builder()
+            .group("group")
+            .localUrl(url5)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        URL url6 = new URL("http://6.6.6.6")
+        Node node6 = Node.builder()
+            .group("group")
+            .localUrl(url6)
+            .offset(offset)
+            .status("following")
+            .following([cloudURL])
+            .build()
+
+        when: "nodes are registered"
+        registry.register(node1)
+        registry.register(node2)
+        registry.register(node3)
+        registry.register(node4)
+        registry.register(node5)
+        registry.register(node6)
+
+        and: "half fail to re-register within the offline delta"
+        sleep 5000
+        registry.register(node3)
+        registry.register(node4)
+        registry.register(node5)
+
+
+        and: "get summary"
+        def followers = registry.getSummary(
+            offset,
+            "status",
+            []
+        ).followers
+
+        then: "nodes are marked as offline and sorted accordingly"
+        followers[0].getLocalUrl() == url3
+        followers[1].getLocalUrl() == url4
+        followers[2].getLocalUrl() == url5
+        followers[3].getLocalUrl() == url1
+        followers[4].getLocalUrl() == url2
+        followers[5].getLocalUrl() == url6
+
+        followers[0].requestedToFollow == [cloudURL]
+        followers[1].requestedToFollow == [url3, cloudURL]
+        followers[2].requestedToFollow == [url3, cloudURL]
+        followers[3].requestedToFollow == [url4, url3, cloudURL]
+        followers[4].requestedToFollow == [url4, url3, cloudURL]
+        followers[5].requestedToFollow == [url5, url3, cloudURL]
+    }
+
     @Unroll
     def "registry can filter by groups"() {
         given: "A registry with a few nodes in different groups"

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -111,12 +111,11 @@ public class NodeGroup {
     }
 
     public void sortOfflineNodes(final URL cloudUrl) {
-        //nodes.sort(Comparator.comparing(n -> n.getStatus().equals("offline") ? "offline" : ""));
-        nodes.sort(this::comparing);
+        nodes.sort(this::compareStatus);
         updateGetFollowing(cloudUrl);
     }
 
-    private int comparing(Node node1, Node node2) {
+    private int compareStatus(Node node1, Node node2) {
         if (isOffline(node1) && !isOffline(node2)) {
             return 1;
         } else if (isOffline(node1) && isOffline(node2)) {

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -116,15 +116,19 @@ public class NodeGroup {
         updateGetFollowing(cloudUrl);
     }
 
-    private int comparing(Node n1, Node n2) {
-        if (n1.getStatus().equals("offline") && !n2.getStatus().equals("offline")) {
+    private int comparing(Node node1, Node node2) {
+        if (isOffline(node1) && !isOffline(node2)) {
             return 1;
-        } else if (n1.getStatus().equals("offline") && n2.getStatus().equals("offline")) {
+        } else if (isOffline(node1) && isOffline(node2)) {
             return 0;
-        } else if (!n1.getStatus().equals("offline") && n2.getStatus().equals("offline")) {
+        } else if (!isOffline(node1) && isOffline(node2)) {
             return -1;
         } else {
             return 0;
         }
+    }
+
+    private boolean isOffline(Node node) {
+        return node.getStatus().equals("offline");
     }
 }

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -3,11 +3,9 @@ package com.tesco.aqueduct.registry.model;
 import com.tesco.aqueduct.pipe.api.JsonHelper;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -113,18 +111,20 @@ public class NodeGroup {
     }
 
     public void sortOfflineNodes(final URL cloudUrl) {
-        Comparator<Node> statusComparator = (n1, n2) -> {
-            if (n1.getStatus().equals("offline") && !n2.getStatus().equals("offline")) {
-                return 1;
-            } else if (!n1.getStatus().equals("offline") && n2.getStatus().equals("offline"){
-                return -1;
-            } else {
-                return 2;
-            }
-        };
-
-//        nodes.sort(Comparator.comparing(n -> n.getStatus().equals("offline") ? "offline" : ""));
-        nodes.sort(statusComparator);
+        //nodes.sort(Comparator.comparing(n -> n.getStatus().equals("offline") ? "offline" : ""));
+        nodes.sort(this::comparing);
         updateGetFollowing(cloudUrl);
+    }
+
+    private int comparing(Node n1, Node n2) {
+        if (n1.getStatus().equals("offline") && !n2.getStatus().equals("offline")) {
+            return 1;
+        } else if (n1.getStatus().equals("offline") && n2.getStatus().equals("offline")) {
+            return 0;
+        } else if (!n1.getStatus().equals("offline") && n2.getStatus().equals("offline")) {
+            return -1;
+        } else {
+            return 0;
+        }
     }
 }

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -68,13 +68,16 @@ public class NodeGroup {
         throw new IllegalStateException("The node was not found " + updatedNode.getId());
     }
 
+    private void updateNodeByIndex(final Node updatedNode, int index) {
+        nodes.set(index, updatedNode);
+    }
+
     public String nodesToJson() throws IOException {
         return JsonHelper.toJson(nodes);
     }
 
     public void updateGetFollowing(final URL cloudUrl) {
-        final List<URL> allUrls = getNodeUrls();
-        for (int i = 0; i < allUrls.size(); i++) {
+        for (int i = 0; i < nodes.size(); i++) {
             final List<URL> followUrls = getFollowerUrls(cloudUrl, i);
             final Node updatedNode = nodes
                 .get(i)
@@ -82,7 +85,7 @@ public class NodeGroup {
                 .requestedToFollow(followUrls)
                 .build();
 
-            this.updateNode(updatedNode);
+            this.updateNodeByIndex(updatedNode, i);
         }
     }
 
@@ -92,20 +95,20 @@ public class NodeGroup {
 
     private List<URL> getFollowerUrls(final URL cloudUrl, int nodeIndex) {
         final List<URL> followUrls = new ArrayList<>();
-        final List<URL> allUrls = getNodeUrls();
-        if (nodeIndex < 0) nodeIndex = allUrls.size();
+        if (nodeIndex < 0) nodeIndex = nodes.size();
         while (nodeIndex != 0) {
             nodeIndex = ((nodeIndex + 1) / NUMBER_OF_CHILDREN_PER_NODE) - 1;
-            followUrls.add(allUrls.get(nodeIndex));
+            followUrls.add(nodes.get(nodeIndex).getLocalUrl());
         }
         followUrls.add(cloudUrl);
         return followUrls;
     }
 
     public void markNodesOfflineIfNotSeenSince(final ZonedDateTime threshold) {
-        for (final Node node : nodes) {
+        for (int i = 0; i < nodes.size(); i++) {
+            Node node = nodes.get(i);
             if (node.getLastSeen().compareTo(threshold) < 0) {
-                this.updateNode(node.toBuilder().status("offline").build());
+                updateNodeByIndex(node.toBuilder().status("offline").build(), i);
             }
         }
     }

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -3,9 +3,11 @@ package com.tesco.aqueduct.registry.model;
 import com.tesco.aqueduct.pipe.api.JsonHelper;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -72,7 +74,7 @@ public class NodeGroup {
         return JsonHelper.toJson(nodes);
     }
 
-    public void rebalance(final URL cloudUrl) {
+    public void updateGetFollowing(final URL cloudUrl) {
         final List<URL> allUrls = getNodeUrls();
         for (int i = 0; i < allUrls.size(); i++) {
             final List<URL> followUrls = getFollowerUrls(cloudUrl, i);
@@ -108,5 +110,21 @@ public class NodeGroup {
                 this.updateNode(node.toBuilder().status("offline").build());
             }
         }
+    }
+
+    public void sortOfflineNodes(final URL cloudUrl) {
+        Comparator<Node> statusComparator = (n1, n2) -> {
+            if (n1.getStatus().equals("offline") && !n2.getStatus().equals("offline")) {
+                return 1;
+            } else if (!n1.getStatus().equals("offline") && n2.getStatus().equals("offline"){
+                return -1;
+            } else {
+                return 2;
+            }
+        };
+
+//        nodes.sort(Comparator.comparing(n -> n.getStatus().equals("offline") ? "offline" : ""));
+        nodes.sort(statusComparator);
+        updateGetFollowing(cloudUrl);
     }
 }

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -95,12 +95,15 @@ public class NodeGroup {
 
     private List<URL> getFollowerUrls(final URL cloudUrl, int nodeIndex) {
         final List<URL> followUrls = new ArrayList<>();
-        if (nodeIndex < 0) nodeIndex = nodes.size();
-        while (nodeIndex != 0) {
-            nodeIndex = ((nodeIndex + 1) / NUMBER_OF_CHILDREN_PER_NODE) - 1;
-            followUrls.add(nodes.get(nodeIndex).getLocalUrl());
+
+        if (nodeIndex == 0) {
+            followUrls.add(cloudUrl);
+        } else {
+            int parentNodeIndex = ((nodeIndex + 1) / NUMBER_OF_CHILDREN_PER_NODE) - 1;
+            followUrls.add(nodes.get(parentNodeIndex).getLocalUrl());
+            followUrls.addAll(nodes.get(parentNodeIndex).getRequestedToFollow());
         }
-        followUrls.add(cloudUrl);
+
         return followUrls;
     }
 
@@ -114,15 +117,13 @@ public class NodeGroup {
     }
 
     public void sortOfflineNodes(final URL cloudUrl) {
-        nodes.sort(this::compareStatus);
+        nodes.sort(this::comparingStatus);
         updateGetFollowing(cloudUrl);
     }
 
-    private int compareStatus(Node node1, Node node2) {
+    private int comparingStatus(Node node1, Node node2) {
         if (isOffline(node1) && !isOffline(node2)) {
             return 1;
-        } else if (isOffline(node1) && isOffline(node2)) {
-            return 0;
         } else if (!isOffline(node1) && isOffline(node2)) {
             return -1;
         } else {

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -46,6 +46,7 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
                 final PostgresNodeGroup group = nodeGroupStorage.getNodeGroup(connection, nodeToRegister.getGroup());
 
                 Node node = addOrUpdateNodeToGroup(nodeToRegister, group);
+
                 group.markNodesOfflineIfNotSeenSince(ZonedDateTime.now().minus(offlineDelta));
                 group.sortOfflineNodes(cloudUrl);
                 group.persist(connection);

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -53,9 +53,7 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
                     group.updateNode(node);
                 }
 
-                //group.markNodesOfflineIfNotSeenSince();
-
-                //group.sortBasedOnStatus();
+                group.sortOfflineNodes(cloudUrl);
 
                 group.persist(connection);
 

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
@@ -246,6 +246,57 @@ class NodeGroupSpec extends Specification {
         group.nodes.get(5).requestedToFollow == [n5Url, n3Url, cloudUrl]
     }
 
+    def "Nodes maintain sort order when none are offline"() {
+        given: "a cloud url"
+        URL cloudUrl = new URL("http://cloud")
+
+        and: "a nodegroup with balanced but no offline nodes"
+        URL n1Url = new URL("http://node-1")
+        Node n1 = Node.builder()
+            .localUrl(n1Url)
+            .requestedToFollow([cloudUrl])
+            .status("following")
+            .build()
+        URL n2Url = new URL("http://node-2")
+        Node n2 = Node.builder()
+            .localUrl(n2Url)
+            .requestedToFollow([n1Url, cloudUrl])
+            .status("pending")
+            .build()
+        URL n3Url = new URL("http://node-3")
+        Node n3 = Node.builder()
+            .localUrl(n3Url)
+            .requestedToFollow([n1Url, cloudUrl])
+            .status("following")
+            .build()
+        URL n4Url = new URL("http://node-4")
+        Node n4 = Node.builder()
+            .localUrl(n4Url)
+            .requestedToFollow([n2Url, n1Url, cloudUrl])
+            .status("pending")
+            .build()
+        URL n5Url = new URL("http://node-5")
+        Node n5 = Node.builder()
+            .localUrl(n5Url)
+            .requestedToFollow([n2Url, n1Url, cloudUrl])
+            .status("initialising")
+            .build()
+        URL n6Url = new URL("http://node-6")
+        Node n6 = Node.builder()
+            .localUrl(n6Url)
+            .requestedToFollow([n3Url, n1Url, cloudUrl])
+            .status("following")
+            .build()
+
+        NodeGroup group = new NodeGroup([n1, n2, n3, n4, n5, n6])
+
+        when: "sort based on status is called"
+        group.sortOfflineNodes(cloudUrl)
+
+        then: "the sort order is unchanged"
+        group.nodes == [n1, n2, n3, n4, n5, n6]
+    }
+
     def "NodeGroup nodes json format is correct"() {
         given: "a NodeGroup"
         URL n1Url = new URL("http://node-1")

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
@@ -181,11 +181,69 @@ class NodeGroupSpec extends Specification {
             .build()
         NodeGroup group = new NodeGroup([n1, n2, n3])
         when: "the group is rebalanced"
-        group.rebalance(cloudUrl)
+        group.updateGetFollowing(cloudUrl)
         then: "the result is a balanced group"
         group.nodes.get(0).requestedToFollow == [cloudUrl]
         group.nodes.get(1).requestedToFollow == [n1Url, cloudUrl]
         group.nodes.get(2).requestedToFollow == [n1Url, cloudUrl]
+    }
+
+    def "Nodes are sorted based on status"() {
+        given: "a cloud url"
+        URL cloudUrl = new URL("http://cloud")
+
+        and: "a nodegroup with balanced, but partially offline nodes"
+        URL n1Url = new URL("http://node-1")
+        Node n1 = Node.builder()
+            .localUrl(n1Url)
+            .requestedToFollow([cloudUrl])
+            .status("offline")
+            .build()
+        URL n2Url = new URL("http://node-2")
+        Node n2 = Node.builder()
+            .localUrl(n2Url)
+            .requestedToFollow([n1Url, cloudUrl])
+            .status("offline")
+            .build()
+        URL n3Url = new URL("http://node-3")
+        Node n3 = Node.builder()
+            .localUrl(n3Url)
+            .requestedToFollow([n1Url, cloudUrl])
+            .status("following")
+            .build()
+        URL n4Url = new URL("http://node-4")
+        Node n4 = Node.builder()
+            .localUrl(n4Url)
+            .requestedToFollow([n2Url, n1Url, cloudUrl])
+            .status("pending")
+            .build()
+        URL n5Url = new URL("http://node-5")
+        Node n5 = Node.builder()
+            .localUrl(n5Url)
+            .requestedToFollow([n2Url, n1Url, cloudUrl])
+            .status("initialising")
+            .build()
+        URL n6Url = new URL("http://node-6")
+        Node n6 = Node.builder()
+            .localUrl(n6Url)
+            .requestedToFollow([n3Url, n1Url, cloudUrl])
+            .status("offline")
+            .build()
+
+        NodeGroup group = new NodeGroup([n1, n2, n3, n4, n5, n6])
+
+        when: "sort based on status is called"
+        group.sortOfflineNodes(cloudUrl)
+
+        then: "nodes that are offline are sorted to be leaves"
+        group.nodes.stream().map({ n -> n.getLocalUrl() }).collect() == [n3Url, n4Url, n5Url, n1Url, n2Url, n6Url]
+
+        group.nodes.get(0).requestedToFollow == [cloudUrl]
+        group.nodes.get(1).requestedToFollow == [n3Url, cloudUrl]
+        group.nodes.get(2).requestedToFollow == [n3Url, cloudUrl]
+        group.nodes.get(3).requestedToFollow == [n4Url, n3Url, cloudUrl]
+        group.nodes.get(4).requestedToFollow == [n4Url, n3Url, cloudUrl]
+        group.nodes.get(5).requestedToFollow == [n5Url, n3Url, cloudUrl]
     }
 
     def "NodeGroup nodes json format is correct"() {

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
@@ -9,21 +9,25 @@ import java.time.Duration
 class PostgreSQLNodeRegistrySpec extends Specification {
 	def "New node can register"() {
 		given: "a mock node group factory"
-			def cloudUrl = new URL("http://cloud.url")
-			def mockNodeGroup = Mock(PostgresNodeGroup)
-			1* mockNodeGroup.getById(_) >> null
-			1* mockNodeGroup.add(_, _) >> Node.builder().requestedToFollow([cloudUrl]).build()
-			def mockNodeGroupFactory = Mock(PostgresNodeGroupStorage)
-			1* mockNodeGroupFactory.getNodeGroup(_, _) >> mockNodeGroup
+		def cloudUrl = new URL("http://cloud.url")
+		def mockNodeGroup = Mock(PostgresNodeGroup)
+		1* mockNodeGroup.getById(_) >> null
+		1* mockNodeGroup.add(_, _) >> Node.builder().requestedToFollow([cloudUrl]).build()
+		def mockNodeGroupFactory = Mock(PostgresNodeGroupStorage)
+		1* mockNodeGroupFactory.getNodeGroup(_, _) >> mockNodeGroup
+
 		and: "a node registry"
-			def dataSourceMock = Mock(DataSource)
-			def offlineDelta = Duration.ofMinutes(5)
-			def registry = new PostgreSQLNodeRegistry(dataSourceMock, cloudUrl, offlineDelta, mockNodeGroupFactory)
+		def dataSourceMock = Mock(DataSource)
+		def offlineDelta = Duration.ofMinutes(5)
+		def registry = new PostgreSQLNodeRegistry(dataSourceMock, cloudUrl, offlineDelta, mockNodeGroupFactory)
+
 		and: "a node to register"
-			def testNode = Mock(Node)
+		def testNode = Mock(Node)
+
 		when: "registering the node"
-			def result = registry.register(testNode)
+		def result = registry.register(testNode)
+
 		then: "we cloud url is returned"
-			result == [cloudUrl]
+		result == [cloudUrl]
 	}
 }


### PR DESCRIPTION
Nodes are now marked as offline proactively on registration, and this is used to inform the hierarchy that is returned.

Some optimisation to the registry code too, which allowed performance tests to pass.