### PR TITLE
Pipe state will be UNKNOWN if no persisted state found

### DIFF
--- a/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/PipeState.java
+++ b/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/PipeState.java
@@ -1,5 +1,5 @@
 package com.tesco.aqueduct.pipe.api;
 
 public enum PipeState {
-    UP_TO_DATE, OUT_OF_DATE
+    UP_TO_DATE, OUT_OF_DATE, UNKNOWN
 }

--- a/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
+++ b/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
@@ -220,14 +220,14 @@ class SQLiteStorageIntegrationSpec extends Specification {
         message == retrievedMessage
     }
 
-    def 'message with default pipe state as OUT_OF_DATE is returned when no state exists in the database'() {
+    def 'message with pipe state as UNKNOWN is returned when no state exists in the database'() {
         given: "no pipe state exist in the database"
 
         when: 'we retrieve the message from the database'
         MessageResults messageResults = sqliteStorage.read(null, 0, "locationUuid")
 
         then: 'the pipe states should be defaulted to OUT_OF_DATE'
-        messageResults.pipeState == PipeState.OUT_OF_DATE
+        messageResults.pipeState == PipeState.UNKNOWN
     }
 
     def 'newly stored message with offset and pipe_state is successfully retrieved from the database'() {

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
@@ -92,7 +92,7 @@ public class SQLiteStorage implements MessageStorage {
                 try (ResultSet resultSet = statement.executeQuery()) {
                     return resultSet.next()
                         ? PipeState.valueOf(resultSet.getString("value"))
-                        : PipeState.OUT_OF_DATE;
+                        : PipeState.UNKNOWN;
                 }
             }
         );


### PR DESCRIPTION
- Introduced Unknown pipe state to represent not found pipe state.

This state will be useful to keep Provider backwards compatible in case it does not get pipe state in the response to pull messages. In which case it should invoke getPipeState endpoint as a fallback mechanism.