### PR TITLE
#131 LC/AS:

### DIFF
--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenProvider.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenProvider.java
@@ -2,10 +2,14 @@ package com.tesco.aqueduct.pipe.identity.issuer;
 
 import com.tesco.aqueduct.pipe.api.IdentityToken;
 import com.tesco.aqueduct.pipe.api.TokenProvider;
+import com.tesco.aqueduct.pipe.logger.PipeLogger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
 public class IdentityIssueTokenProvider implements TokenProvider {
+
+    private static final PipeLogger LOG = new PipeLogger(LoggerFactory.getLogger(IdentityIssueTokenProvider.class));
 
     private final IdentityIssueTokenClient identityIssueTokenClient;
     private final String identityClientId;
@@ -27,14 +31,20 @@ public class IdentityIssueTokenProvider implements TokenProvider {
         if (identityToken != null && !identityToken.isTokenExpired()) {
             return identityToken;
         }
+        final String traceId = UUID.randomUUID().toString();
 
-        identityToken = identityIssueTokenClient.retrieveIdentityToken(
-            UUID.randomUUID().toString(),
-            new IssueTokenRequest(
-                identityClientId,
-                identityClientSecret
-            )
-        );
+        try {
+            identityToken = identityIssueTokenClient.retrieveIdentityToken(
+                    traceId,
+                    new IssueTokenRequest(
+                            identityClientId,
+                            identityClientSecret
+                    )
+            );
+        } catch(Exception exception) {
+            LOG.error("retrieveIdentityToken", "trace_id: " + traceId, exception);
+            throw exception;
+        }
 
         return identityToken;
     }

--- a/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenClientIntegrationSpec.groovy
+++ b/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenClientIntegrationSpec.groovy
@@ -81,6 +81,7 @@ class IdentityIssueTokenClientIntegrationSpec extends Specification {
                 body(requestJson, "application/json")
                 header("Accept", "application/vnd.tesco.identity.tokenresponse+json")
                 header("TraceId", "someTraceId")
+                header("Content-Type", "application/json")
                 called(1)
 
                 responder {


### PR DESCRIPTION
- Added traceId in error log when request to identity for issuing token fails.