### PR TITLE
#131 LC/AS/SL: Fix annoying Identity issue

### DIFF
--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenClient.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenClient.java
@@ -1,6 +1,5 @@
 package com.tesco.aqueduct.pipe.identity.issuer;
 
-import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
@@ -8,7 +7,6 @@ import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.CircuitBreaker;
 
 @Client("${authentication.identity.url}")
-@Header(name = "Content-Type", value = MediaType.APPLICATION_JSON)
 public interface IdentityIssueTokenClient {
 
     @Post(value = "${authentication.identity.issue.token.path}", consumes = "application/vnd.tesco.identity.tokenresponse+json")

--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/location/CloudLocationResolver.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/location/CloudLocationResolver.java
@@ -20,6 +20,7 @@ public class CloudLocationResolver implements LocationResolver {
 
     @Override
     public List<String> resolve(String location) {
+        tokenProvider.retrieveIdentityToken();
         return Collections.emptyList();
     }
 }

--- a/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/location/CloudLocationResolverSpec.groovy
+++ b/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/location/CloudLocationResolverSpec.groovy
@@ -2,10 +2,8 @@ package com.tesco.aqueduct.pipe.location
 
 import com.tesco.aqueduct.pipe.api.IdentityToken
 import com.tesco.aqueduct.pipe.identity.issuer.IdentityIssueTokenProvider
-import spock.lang.Ignore
 import spock.lang.Specification
 
-@Ignore
 class CloudLocationResolverSpec extends Specification {
 
     def "Identity token is issued and return empty list"() {


### PR DESCRIPTION
- Removed header annotation at the class level as Micronaut by default includes content-type header anyway and having this annotation results in duplicate content-type headers which Identity service does not like.