### PR TITLE
Remove get offset by type

### DIFF
--- a/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/Reader.java
+++ b/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/Reader.java
@@ -7,7 +7,4 @@ public interface Reader {
     MessageResults read(List<String> types, long offset, final List<String> targetUuids);
     OptionalLong getOffset(OffsetName offsetName);
     PipeState getPipeState();
-
-    @Deprecated
-    long getLatestOffsetMatching(List<String> types);
 }

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClientIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClientIntegrationSpec.groovy
@@ -105,46 +105,4 @@ class InternalHttpPipeClientIntegrationSpec extends Specification {
         "type1" | "location1" | "contentType3" | 111
         "type2" | "location2" | "contentType4" | 123
     }
-
-    def "can get latest offset"(){
-        given:
-        server.expectations {
-            get("/pipe/offset/latest") {
-                called(1)
-
-                responder {
-                    contentType('application/json')
-                    body('123')
-                }
-            }
-        }
-
-        when:
-        def latest = client.getLatestOffsetMatching([])
-        then:
-        server.verify()
-        latest == 123
-    }
-
-    def "can get latest offset with tags"(){
-        given:
-        server.expectations {
-            get("/pipe/offset/latest") {
-                called(1)
-                query("type","a,b,c")
-
-                responder {
-                    contentType('application/json')
-                    body('100')
-                }
-            }
-        }
-
-        when:
-        def latest = client.getLatestOffsetMatching(["a", "b", "c"])
-
-        then:
-        server.verify()
-        latest == 100
-    }
 }

--- a/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
+++ b/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
@@ -47,7 +47,7 @@ public class HttpPipeClient implements Reader {
         return new MessageResults(
             response.body(),
             retryAfter,
-            OptionalLong.of(getLatestGlobalOffset(types, response)),
+            OptionalLong.of(getGlobalOffsetHeader(response)),
             getPipeState(response)
         );
     }
@@ -62,23 +62,11 @@ public class HttpPipeClient implements Reader {
         throw new UnsupportedOperationException("HttpPipeClient does not support this operation.");
     }
 
-    private long getLatestGlobalOffset(@Nullable List<String> types, HttpResponse<List<Message>> response) {
-        // TODO - Ensure backwards compatible, need to update to throw error once all tills have latest software
-        return getGlobalOffsetHeader(response) == null
-            ? getLatestOffsetMatching(types)
-            : Long.parseLong(getGlobalOffsetHeader(response));
-    }
-
-    private String getGlobalOffsetHeader(HttpResponse<List<Message>> response) {
-        return response.header(HttpHeaders.GLOBAL_LATEST_OFFSET);
+    private Long getGlobalOffsetHeader(HttpResponse<List<Message>> response) {
+        return Long.parseLong(response.header(HttpHeaders.GLOBAL_LATEST_OFFSET));
     }
 
     private PipeState getPipeState(HttpResponse<List<Message>> response) {
         return PipeState.valueOf(response.header(HttpHeaders.PIPE_STATE));
-    }
-
-    @Override
-    public long getLatestOffsetMatching(final List<String> types) {
-        return client.getLatestOffsetMatching(types);
     }
 }

--- a/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClient.java
+++ b/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/InternalHttpPipeClient.java
@@ -23,9 +23,4 @@ public interface InternalHttpPipeClient {
         long offset,
         String location
     );
-
-    @Get("/pipe/offset/latest{?type}")
-    @Header(name="Accept-Encoding", value="gzip, deflate")
-    @Retryable(attempts = "${pipe.http.latest-offset.attempts}", delay = "${pipe.http.latest-offset.delay}")
-    long getLatestOffsetMatching(@Nullable List<String> type);
 }

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
@@ -43,22 +43,6 @@ class HttpPipeClientSpec extends Specification {
         "foo" | 0
     }
 
-    // Ensure backwards compatible, need to update to throw error once all tills have latest software
-    def "if no global offset is available in the header, call getLatestOffsetMatching"() {
-        given: "call returns a http response with retry after header"
-        HttpResponse<List<Message>> response = Mock()
-        response.body() >> [Mock(Message)]
-        response.header(HttpHeaders.RETRY_AFTER) >> 1
-        response.header(HttpHeaders.PIPE_STATE) >> PipeState.UP_TO_DATE
-        internalClient.httpRead(_ as List, _ as Long, _ as String) >> response
-
-        when: "we call read"
-        client.read([], 0, ["locationUuid"])
-
-        then: "getLatestOffsetMatching is called"
-        1 * internalClient.getLatestOffsetMatching(_)
-    }
-
     def "if global offset is available in the header, it should be returned in MessageResults"() {
         given: "call returns a http response with global offset header"
         HttpResponse<List<Message>> response = Mock()
@@ -109,22 +93,6 @@ class HttpPipeClientSpec extends Specification {
 
         then: "an exception is thrown"
         thrown Exception
-    }
-
-    def "allows to get latest offset"() {
-        given:
-        internalClient.getLatestOffsetMatching(types) >> offset
-
-        when:
-        def response = client.getLatestOffsetMatching(types)
-
-        then:
-        response == offset
-
-        where:
-        types  | offset
-        ["x"]  | 1
-        []     | 2
     }
 
     def "throws unsupported operation error when getOffset invoked"() {

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
@@ -79,22 +79,6 @@ class HttpPipeClientSpec extends Specification {
 
     }
 
-    def "an exception is thrown when getLatestOffsetMatching fails"() {
-        given: "call returns a http response with retry after header"
-        HttpResponse<List<Message>> response = Mock()
-        response.body() >> [Mock(Message)]
-        response.header(HttpHeaders.RETRY_AFTER) >> 1
-
-        internalClient.httpRead(_ as List, _ as Long, _ as String) >> response
-        internalClient.getLatestOffsetMatching(_ as List) >> { throw new Exception() }
-
-        when: "we call read"
-        client.read([], 0, ["locationUuid"])
-
-        then: "an exception is thrown"
-        thrown Exception
-    }
-
     def "throws unsupported operation error when getOffset invoked"() {
         when:
         client.getOffset(OffsetName.GLOBAL_LATEST_OFFSET)

--- a/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
+++ b/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
@@ -2,6 +2,7 @@ import com.opentable.db.postgres.junit.EmbeddedPostgresRules
 import com.opentable.db.postgres.junit.SingleInstancePostgresRule
 import com.stehno.ersatz.Decoders
 import com.stehno.ersatz.ErsatzServer
+import com.tesco.aqueduct.pipe.api.OffsetName
 import com.tesco.aqueduct.pipe.api.PipeState
 import com.tesco.aqueduct.pipe.api.Reader
 import com.tesco.aqueduct.registry.model.NodeRegistry
@@ -115,6 +116,10 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
 
         setupDatabase()
 
+        Reader reader = Mock(Reader) {
+            getOffset(OffsetName.GLOBAL_LATEST_OFFSET) >> OptionalLong.of(100L);
+        }
+
         context = ApplicationContext
                 .build()
                 .properties(
@@ -153,7 +158,7 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
             )
             .build()
             .registerSingleton(NodeRegistry, registry)
-            .registerSingleton(Reader, Mock(Reader))
+            .registerSingleton(Reader, reader)
             .registerSingleton(TillStorage, tillStorage)
             .start()
 

--- a/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerIntegrationDeprecatedSpec.groovy
+++ b/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerIntegrationDeprecatedSpec.groovy
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 import static org.hamcrest.Matchers.equalTo
 
 @Newify(Message)
-@Deprecated // Remove this test when /offset/latest and /pipe/state endpoints are removed
+@Deprecated // Remove this test when /pipe/state endpoints is removed
 class PipeReadControllerIntegrationDeprecatedSpec extends Specification {
     public static final String SOME_CLUSTER = "someCluster"
 
@@ -71,52 +71,6 @@ class PipeReadControllerIntegrationDeprecatedSpec extends Specification {
 
     void cleanupSpec() {
         RestAssured.port = RestAssured.DEFAULT_PORT
-    }
-
-    @Unroll
-    def "Returns latest offset of #types"() {
-        given:
-        storage.write([
-            Message("a", "a", "contentType", 100, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data"),
-            Message("b", "b", "contentType", 101, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data"),
-            Message("c", "c", "contentType", 102, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data")
-        ])
-
-        when:
-        def request = RestAssured.get("/pipe/offset/latest?type=$types")
-
-        then:
-        request
-            .then()
-            .content(equalTo(offset))
-
-        where:
-        types   | offset
-        "a"     | "100"
-        "b"     | "101"
-        "c"     | "102"
-        "b,a"   | "101"
-        "a,c"   | "102"
-        "a,b,c" | "102"
-    }
-
-    def "Latest offset endpoint requires types"() {
-        given:
-        storage.write([
-            new CentralInMemoryStorage.ClusteredMessage(Message("a", "a", "contentType", 100, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data"), SOME_CLUSTER),
-            new CentralInMemoryStorage.ClusteredMessage(Message("b", "b", "contentType", 101, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data"), SOME_CLUSTER),
-            new CentralInMemoryStorage.ClusteredMessage(Message("c", "c", "contentType", 102, ZonedDateTime.parse("2018-12-20T15:13:01Z"), "data"), SOME_CLUSTER)
-        ])
-
-        when:
-        def request = RestAssured.get("/pipe/offset/latest")
-
-        then:
-        def response = """{"message":"Required QueryValue [type] not specified","path":"/type","_links":{"self":{"href":"/pipe/offset/latest","templated":false}}}"""
-        request
-            .then()
-            .statusCode(400)
-            .body(equalTo(response))
     }
 
     def "state endpoint returns result of state provider"() {

--- a/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
+++ b/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
@@ -49,13 +49,6 @@ public class PipeReadController {
     @ReadableBytes @Value("${pipe.http.server.read.response-size-limit-in-bytes:1024kb}")
     private int maxPayloadSizeBytes;
 
-    @Get("/pipe/offset/latest")
-    @Deprecated // remove when its non-usage is confirmed
-    public String latestOffset(@QueryValue final List<String> type) {
-        final List<String> types = flattenRequestParams(type);
-        return Long.toString(reader.getLatestOffsetMatching(types));
-    }
-
     @Get("/pipe/state{?type}")
     @Deprecated // remove when its non-usage is confirmed
     public PipeStateResponse state(@Nullable final List<String> type) {

--- a/pipe-storage-memory/src/main/java/com/tesco/aqueduct/pipe/storage/InMemoryStorage.java
+++ b/pipe-storage-memory/src/main/java/com/tesco/aqueduct/pipe/storage/InMemoryStorage.java
@@ -74,18 +74,6 @@ public abstract class InMemoryStorage implements Reader, Writer {
         return messages.isEmpty() || offset >= messages.get(messages.size()-1).getOffset() ? retryAfter : 0;
     }
 
-    @Override
-    public long getLatestOffsetMatching(final List<String> types) {
-        for (int i = messages.size()-1 ; i >= 0 ; i--) {
-            final Message message = messages.get(i);
-
-            if (messageMatchTypes(message, types)) {
-                return message.getOffset();
-            }
-        }
-        return 0;
-    }
-
     private boolean messageMatchTypes(final Message message, final List<String> types) {
         return types == null || types.isEmpty() || types.contains(message.getType());
     }

--- a/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
+++ b/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
@@ -74,28 +74,6 @@ class PostgresqlStorageIntegrationSpec extends StorageSpec {
         storage = new PostgresqlStorage(dataSource, limit, retryAfter, batchSize)
     }
 
-    def "get the latest offset where tags contains type but no other keys"() {
-        given: "there is postgres storage"
-        def dataSourceWithMockedConnection = Mock(DataSource)
-        def postgresStorage = new PostgresqlStorage(dataSourceWithMockedConnection, limit, 0, batchSize)
-
-        and: "a mock connection is provided when requested"
-        def connection = Mock(Connection)
-        dataSourceWithMockedConnection.getConnection() >> connection
-
-        and: "a connection returns a prepared statement"
-        def preparedStatement = Mock(PreparedStatement)
-        preparedStatement.executeQuery() >> Mock(ResultSet)
-        connection.prepareStatement(_ as String) >> preparedStatement
-
-        when: "requesting the latest matching offset with tags specifying a type key"
-        postgresStorage.getLatestOffsetMatching(["some_type"])
-
-        then: "a query is created that does not contain tags in the where clause"
-        1 * preparedStatement.setString(1, "some_type")
-        0 * preparedStatement.setString(_ as Integer, '{}')
-    }
-
     @Unroll
     def "get #offsetName returns max offset"() {
         given: "there are messages"

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -76,7 +76,7 @@ public class PostgresqlStorage implements CentralStorage {
             return resultSet.getLong("last_offset");
         }finally {
             long end = System.currentTimeMillis();
-            LOG.info("getLatestOffsetMatchingWithConnection:time", Long.toString(end - start));
+            LOG.info("getLatestOffsetWithConnection:time", Long.toString(end - start));
         }
     }
 

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -9,7 +9,6 @@ import java.sql.*;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
 
@@ -58,16 +57,6 @@ public class PostgresqlStorage implements CentralStorage {
     }
 
     @Override
-    public long getLatestOffsetMatching(final List<String> types) {
-        try (Connection connection = dataSource.getConnection()) {
-            return getLatestOffsetMatchingWithConnection(connection, types);
-        } catch (SQLException exception) {
-            LOG.error("postgresql storage", "get latest offeset matching", exception);
-            throw new RuntimeException(exception);
-        }
-    }
-
-    @Override
     public OptionalLong getOffset(OffsetName offsetName) {
         try (Connection connection = dataSource.getConnection()) {
             return OptionalLong.of(getLatestOffsetWithConnection(connection));
@@ -78,15 +67,9 @@ public class PostgresqlStorage implements CentralStorage {
     }
 
     private long getLatestOffsetWithConnection(Connection connection) throws SQLException {
-        return getLatestOffsetMatchingWithConnection(connection, Collections.emptyList());
-    }
-
-    // TODO - Remove the types parameter once we remove getLatestOffset endpoint from PipeReadController
-    private long getLatestOffsetMatchingWithConnection(final Connection connection, final List<String> types)
-            throws SQLException {
         long start = System.currentTimeMillis();
 
-        try (PreparedStatement statement = getLatestOffsetStatement(connection, types);
+        try (PreparedStatement statement = getLatestOffsetStatement(connection);
             ResultSet resultSet = statement.executeQuery()) {
             resultSet.next();
 
@@ -119,21 +102,9 @@ public class PostgresqlStorage implements CentralStorage {
         return messages;
     }
 
-    private PreparedStatement getLatestOffsetStatement(final Connection connection, final List<String> types) {
-
+    private PreparedStatement getLatestOffsetStatement(final Connection connection) {
         try {
-            PreparedStatement query;
-
-            if (types == null || types.isEmpty()) {
-                query = connection.prepareStatement(getSelectLatestOffsetWithoutTypeQuery());
-            } else {
-                final String strTypes = String.join(",", types);
-                query = connection.prepareStatement(getSelectLatestOffsetWithTypeQuery());
-                query.setString(1, strTypes);
-            }
-
-            return query;
-
+            return connection.prepareStatement(getSelectLatestOffsetQuery());
         } catch (SQLException exception) {
             LOG.error("postgresql storage", "get latest offset statement", exception);
             throw new RuntimeException(exception);
@@ -224,14 +195,7 @@ public class PostgresqlStorage implements CentralStorage {
             " clusters.cluster_uuid = ANY (string_to_array(?, ',')) ";
     }
 
-    private static String getSelectLatestOffsetWithTypeQuery() {
-        return
-            " SELECT coalesce(max(msg_offset),0) as last_offset " +
-            " FROM events " +
-            " WHERE type  = ANY (string_to_array(?, ','));";
-    }
-
-    private static String getSelectLatestOffsetWithoutTypeQuery() {
+    private static String getSelectLatestOffsetQuery() {
         return " SELECT coalesce(max(msg_offset),0) as last_offset FROM events ;";
     }
 

--- a/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
+++ b/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
@@ -306,34 +306,6 @@ class SQLiteStorageIntegrationSpec extends Specification {
         messageResults.messages.size() == 3
     }
 
-    def 'retrieves the latest offset'() {
-        given: 'multiple messages to be stored'
-        def messages = [message(1), message(2), message(3), message(4)]
-
-        and: 'these messages are stored'
-        sqliteStorage.write(messages)
-
-        when: 'requesting the latest offset with no tags'
-        def latestOffset = sqliteStorage.getLatestOffsetMatching([])
-
-        then: 'the latest offset is returned'
-        latestOffset == 4
-    }
-
-    def 'retrieves the latest offset for a given type'() {
-        given: 'multiple messages to be stored'
-        def messages = [message(1), message(2, 'my-new-type'), message(3), message(4)]
-
-        and: 'these messages are stored'
-        sqliteStorage.write(messages)
-
-        when: 'requesting the latest offset with no tags'
-        def latestOffset = sqliteStorage.getLatestOffsetMatching(['my-new-type'])
-
-        then: 'the latest offset is returned'
-        latestOffset == 2
-    }
-
     def "the messages returned are no larger than the maximum batch size"() {
         given: "a size of each message is calculated so that 3 messages are just larger than the max overhead batch size"
         int messageSize = Double.valueOf(maxOverheadBatchSize / 3).intValue() + 1
@@ -372,25 +344,6 @@ class SQLiteStorageIntegrationSpec extends Specification {
         receivedMessages.messages.size() == 2
         receivedMessages.messages[0] == messages.get(1)
         receivedMessages.messages[1] == messages.get(2)
-    }
-
-    def 'retrieves the latest offset for multiple specified types'() {
-        given: 'multiple messages to be stored'
-        def messages = [
-            message(1),
-            message(2, 'type-1'),
-            message(3, 'type-2'),
-            message(4)
-        ]
-
-        and: 'these messages are stored'
-        sqliteStorage.write(messages)
-
-        when: 'requesting the latest offset with multiple specified types'
-        def latestOffset = sqliteStorage.getLatestOffsetMatching(['type-1', 'type-2'])
-
-        then: 'the latest offset for the messages with one of the types is returned'
-        latestOffset == 3
     }
 
     def 'retrieves the global latest offset'() {

--- a/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorageIntegrationSpec.groovy
+++ b/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorageIntegrationSpec.groovy
@@ -130,24 +130,4 @@ class TimedDistributedStorageIntegrationSpec extends Specification {
         notThrown(Exception)
         message == retrievedMessage
     }
-
-    def 'we can retrieve the latest offset via TimedMessageStorage'() {
-        given: 'multiple messages to be stored'
-        def messages = [message(1), message(2), message(3), message(4)]
-
-        and: 'a data store controller exists'
-        def sqliteStorage = new SQLiteStorage(successfulDataSource(), LIMIT, 10, BATCH_SIZE)
-
-        and: 'we use the TimedMessageStorage class to wrap sqlLite'
-        TimedDistributedStorage storage = new TimedDistributedStorage(sqliteStorage, meterRegistry)
-
-        and: 'these messages are stored'
-        storage.write(messages)
-
-        when: 'requesting the latest offset with no tags'
-        def latestOffset = storage.getLatestOffsetMatching([])
-
-        then: 'the latest offset is returned'
-        latestOffset == 4
-    }
 }

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
@@ -124,24 +124,6 @@ public class SQLiteStorage implements DistributedStorage {
     }
 
     @Override
-    public long getLatestOffsetMatching(final List<String> types) {
-        final int typesCount = types == null ? 0 : types.size();
-
-        return executeGet(
-            SQLiteQueries.getLastOffsetQuery(typesCount),
-            (connection, statement) -> {
-                for (int i = 0; i < typesCount; i++) {
-                    statement.setString(i + 1, types.get(i));
-                }
-
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    return resultSet.getLong("last_offset");
-                }
-            }
-        );
-    }
-
-    @Override
     public OptionalLong getOffset(OffsetName offsetName) {
         return executeGet(
             SQLiteQueries.getOffset(offsetName),

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorage.java
@@ -36,11 +36,6 @@ public class TimedDistributedStorage implements DistributedStorage {
     }
 
     @Override
-    public long getLatestOffsetMatching(final List<String> types) {
-        return latestOffsetTimer.record(() -> storage.getLatestOffsetMatching(types));
-    }
-
-    @Override
     public OptionalLong getOffset(OffsetName offsetName) {
         return readOffsetTimer.record(() -> storage.getOffset(offsetName));
     }

--- a/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageSpec.groovy
+++ b/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageSpec.groovy
@@ -71,16 +71,6 @@ class SQLiteStorageSpec extends Specification {
         thrown(RuntimeException)
     }
 
-    def 'throws an exception if a problem with the database arises when retrieving latest offset'() {
-        given: 'a data store controller exists with a broken connection url'
-
-        when: 'the latest offset is requested'
-        sqliteStorage.getLatestOffsetMatching([:])
-
-        then: 'a runtime exception is thrown'
-        thrown(RuntimeException)
-    }
-
     def 'throws an exception if a problem with the database arises when writing latest offset'() {
         given: 'a data store controller exists with a broken connection url'
 

--- a/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorageSpec.groovy
+++ b/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/TimedDistributedStorageSpec.groovy
@@ -65,18 +65,6 @@ class TimedDistributedStorageSpec extends Specification {
         1 * mockedStorage.write([MOCK_MESSAGE])
     }
 
-    def "get latest offset events are timed"() {
-        given: "we have an instance of TimedMessageStorage"
-        def mockedStorage = Mock(DistributedStorage)
-        def timedStorage = new TimedDistributedStorage(mockedStorage, METER_REGISTRY)
-
-        when: "we call the get latest offset method"
-        timedStorage.getLatestOffsetMatching(MESSAGE_TYPES)
-
-        then: "the get latest method is called on the underlying storage"
-        1 * mockedStorage.getLatestOffsetMatching(MESSAGE_TYPES)
-    }
-
     def "write offset events are timed"() {
         given: "we have an instance of TimedMessageStorage"
         def mockedStorage = Mock(DistributedStorage)

--- a/pipe-storage-test/src/main/groovy/com/tesco/aqueduct/pipe/storage/StorageSpec.groovy
+++ b/pipe-storage-test/src/main/groovy/com/tesco/aqueduct/pipe/storage/StorageSpec.groovy
@@ -128,29 +128,6 @@ abstract class StorageSpec extends Specification {
         storage.read(null, 0, []).messages.size() == 3
     }
 
-    @Unroll
-    def "find latest offset by types #types" (){
-        given:
-        insert(message(type: "first", key: "x"))
-        insert(message(type: "middle", key: "y"))
-        insert(message(type: "other_type", key: "z"))
-        insert(message(type: "middle", key: "q"))
-        insert(message(type: "last",  key: "w"))
-
-        when:
-        def actualOffset = storage.getLatestOffsetMatching(types)
-
-        then:
-        actualOffset == offset
-
-        where:
-        types       | offset
-        ["first"]   | 1
-        ["middle"]  | 4
-        ["last"]    | 5
-        ["missing"] | 0 // no such type
-    }
-
     abstract Message message(
         Long offset,
         String type,

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/http/NodeRegistryControllerV2.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/http/NodeRegistryControllerV2.java
@@ -1,5 +1,6 @@
 package com.tesco.aqueduct.registry.http;
 
+import com.tesco.aqueduct.pipe.api.OffsetName;
 import com.tesco.aqueduct.pipe.api.Reader;
 import com.tesco.aqueduct.pipe.metrics.Measure;
 import com.tesco.aqueduct.registry.model.*;
@@ -39,7 +40,7 @@ public class NodeRegistryControllerV2 {
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Get
     public StateSummary getSummary(@Nullable final List<String> groups) {
-        return registry.getSummary(pipe.getLatestOffsetMatching(null), Status.OK, groups);
+        return registry.getSummary(pipe.getOffset(OffsetName.GLOBAL_LATEST_OFFSET).getAsLong(), Status.OK, groups);
     }
 
     @Secured(REGISTRY_WRITE)


### PR DESCRIPTION
Remove deprecated endpoint "/pipe/offset/latest" and subsequent methods that take in type to get the latest offset.