### PR TITLE
Row level locking registry

### DIFF
--- a/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/identity/issuer/IssueTokenResponseSpec.groovy
+++ b/pipe-http-server-cloud/src/test/groovy/com/tesco/aqueduct/pipe/identity/issuer/IssueTokenResponseSpec.groovy
@@ -8,8 +8,8 @@ class IssueTokenResponseSpec extends Specification {
         given: "an identity token with expiry time"
         def identityToken = new IssueTokenResponse("someAccessToken", 1)
 
-        when: "one second is passed"
-        sleep(1000)
+        when: "over one second is passed"
+        sleep(1500)
 
         then: "token is expired"
         identityToken.isTokenExpired()

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeGroup.java
@@ -42,7 +42,6 @@ public class NodeGroup {
         return subGroups.isEmpty();
     }
 
-    @Measure
     public boolean removeByHost(final String host) {
         boolean result = subGroups.stream().anyMatch(subgroup -> subgroup.removeByHost(host));
         subGroups.removeIf(SubNodeGroup::isEmpty);
@@ -53,18 +52,15 @@ public class NodeGroup {
         return JsonHelper.toJson(getNodes());
     }
 
-    @Measure
     public List<Node> getNodes() {
         return subGroups.stream()
             .flatMap(subNodeGroup -> subNodeGroup.nodes.stream()).collect(Collectors.toList());
     }
 
-    @Measure
     public void updateGetFollowing(final URL cloudUrl) {
         subGroups.forEach(subgroup -> subgroup.updateGetFollowing(cloudUrl));
     }
 
-    @Measure
     public void markNodesOfflineIfNotSeenSince(final ZonedDateTime threshold) {
         subGroups.forEach(subGroup -> subGroup.markNodesOfflineIfNotSeenSince(threshold));
     }
@@ -73,7 +69,6 @@ public class NodeGroup {
         subGroups.forEach(subGroup -> subGroup.sortOfflineNodes(cloudUrl));
     }
 
-    @Measure
     public Node upsert(final Node nodeToRegister, final URL cloudUrl) {
         SubNodeGroup subGroup = findOrCreateSubGroupFor(nodeToRegister);
 
@@ -113,7 +108,6 @@ public class NodeGroup {
         }
     }
 
-    @Measure
     public void processOfflineNodes(ZonedDateTime threshold, URL cloudUrl) {
         markNodesOfflineIfNotSeenSince(threshold);
         sortOfflineNodes(cloudUrl);

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
@@ -31,7 +31,6 @@ public class SubNodeGroup {
         return node.getSubGroupId().equals(subGroupId);
     }
 
-    @Measure
     public Node add(Node node, URL cloudUrl) {
         final List<URL> followUrls = calculateFollowerUrls(cloudUrl, getNodeUrls().size());
         final Node newNode = node.buildWith(followUrls);
@@ -121,7 +120,6 @@ public class SubNodeGroup {
         }
     }
 
-    @Measure
     public Node update(final Node currentNode, final Node nodeToRegister) {
         return nodes.set(nodes.indexOf(currentNode), nodeToRegister.buildWith(currentNode.getRequestedToFollow()));
     }

--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -345,7 +345,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         when: "nodes register concurrently"
         ExecutorService pool = Executors.newFixedThreadPool(threads)
         PollingConditions conditions = new PollingConditions(timeout: timeout)
-        iterations.times{ i ->
+        nodes.times{ i ->
             pool.execute{
                 registerNode("x", "http://" + i, i)
             }
@@ -353,7 +353,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
 
         then: "summary of the registry is as expected"
         conditions.eventually {
-            assert registry.getSummary(0, INITIALISING, ["x"]).followers.size() == iterations
+            assert registry.getSummary(0, INITIALISING, ["x"]).followers.size() == nodes
         }
 
         cleanup:
@@ -361,21 +361,21 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
 
         where:
 
-        iterations | threads | timeout | name
-        2          | 2       | 5       | "case A" // we have seen bad changes to the code that make case A and B pass/fail in a non-deterministic way, hence they're here
-        2          | 2       | 5       | "case B"
-        1          | 1       | 1       | "1 node"
-        10         | 1       | 1       | "1 node 10 calls"
-        2          | 2       | 1       | "2 nodes"
-        10         | 2       | 5       | "2 nodes 10 calls"
-        3          | 3       | 1       | "3 nodes"
-        10         | 3       | 5       | "3 nodes 10 calls"
-        100        | 3       | 5       | "3 nodes 100 calls"
-        500        | 3       | 20      | "3 nodes 500 calls"
-        10         | 10      | 3       | "10 nodes"
-        50         | 50      | 3       | "50 nodes"
-        100        | 100     | 5       | "100 nodes"
-        250        | 250     | 10      | "250 nodes"
+        nodes | threads | timeout | name
+        2     | 2       | 5       | "case A" // we have seen bad changes to the code that make case A and B pass/fail in a non-deterministic way, hence they're here
+        2     | 2       | 5       | "case B"
+        1     | 1       | 1       | "1 node with concurrency 1"
+        10    | 1       | 1       | "10 node with concurrency 1"
+        2     | 2       | 1       | "2 nodes with concurrency 1"
+        10    | 2       | 5       | "10 nodes with concurrency 2"
+        3     | 3       | 1       | "3 nodes with concurrency 3"
+        10    | 3       | 5       | "10 nodes with concurrency 3"
+        100   | 3       | 5       | "100 nodes with concurrency 3"
+        300   | 3       | 20      | "300 nodes with concurrency 3"
+        10    | 10      | 3       | "10 nodes with concurrency 10"
+        50    | 50      | 3       | "50 nodes with concurrency 50"
+        100   | 100     | 5       | "100 nodes with concurrency 100"
+        250   | 250     | 10      | "250 nodes with concurrency 250"
     }
 
     def "node registry can handle concurrent multiple group requests (10 stores with 50 nodes each)"() {

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -76,7 +76,7 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
     private List<PostgresNodeGroup> getPostgresNodeGroups(List<String> groupIds) {
         List<PostgresNodeGroup> groups;
         try (Connection connection = getConnection()) {
-            groups = nodeGroupStorage.getNodeGroups(connection, groupIds);
+            groups = nodeGroupStorage.readNodeGroups(connection, groupIds);
         } catch (SQLException | IOException exception) {
             LOG.error("Postgresql node registry", "get summary", exception);
             throw new RuntimeException(exception);

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -15,8 +15,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class PostgreSQLNodeRegistry implements NodeRegistry {
-    private static final long OPTIMISTIC_LOCKING_COOLDOWN_MS = 500L;
-    private static final int OPTIMISTIC_LOCKING_COOLDOWN_RANDOM_BOUND = 500;
     private static final Random random = new Random();
     private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(PostgreSQLNodeRegistry.class));
 

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -38,30 +38,18 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
 
     @Override
     public List<URL> register(final Node nodeToRegister) {
-        int count = 0;
-        while (count < 10) {
-            try (Connection connection = getConnection()) {
-                final PostgresNodeGroup group = nodeGroupStorage.getNodeGroup(connection, nodeToRegister.getGroup());
-                Node node = group.upsert(nodeToRegister, cloudUrl);
+        try (Connection connection = getConnection()) {
+            final PostgresNodeGroup group = nodeGroupStorage.getNodeGroup(connection, nodeToRegister.getGroup());
+            Node node = group.upsert(nodeToRegister, cloudUrl);
 
-                group.processOfflineNodes(ZonedDateTime.now().minus(offlineDelta), cloudUrl);
-                group.persist(connection);
+            group.processOfflineNodes(ZonedDateTime.now().minus(offlineDelta), cloudUrl);
+            group.persist(connection);
 
-                return node.getRequestedToFollow();
-            } catch (SQLException | IOException exception) {
-                LOG.error("Postgresql node registry", "register node", exception);
-                throw new RuntimeException(exception);
-            } catch (VersionChangedException exception) {
-                try {
-                    LOG.info("Postgresql version changed exception", Integer.toString(++count));
-                    Thread.sleep(OPTIMISTIC_LOCKING_COOLDOWN_MS + random.nextInt(OPTIMISTIC_LOCKING_COOLDOWN_RANDOM_BOUND));
-                } catch (InterruptedException e) {
-                    LOG.info("register", "Interrupted waiting for Version store");
-                    Thread.currentThread().interrupt();
-                }
-            }
+            return node.getRequestedToFollow();
+        } catch (SQLException | IOException exception) {
+            LOG.error("Postgresql node registry", "register node", exception);
+            throw new RuntimeException(exception);
         }
-        throw new RuntimeException("Failed to register");
     }
 
     private Connection getConnection() throws SQLException {
@@ -110,25 +98,17 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
 
     @Override
     public boolean deleteNode(final String groupId, final String host) {
-        while (true) {
-            try (Connection connection = getConnection()) {
-                final PostgresNodeGroup nodeGroup = nodeGroupStorage.getNodeGroup(connection, groupId);
+        try (Connection connection = getConnection()) {
+            final PostgresNodeGroup nodeGroup = nodeGroupStorage.getNodeGroup(connection, groupId);
 
-                if(nodeGroup.isEmpty()) {
-                    return false;
-                } else {
-                    return deleteExistingNode(connection, host, nodeGroup);
-                }
-            } catch (SQLException | IOException exception) {
-                LOG.error("Postgresql node registry", "deleteNode", exception);
-                throw new RuntimeException(exception);
-            } catch (VersionChangedException exception) {
-                try {
-                    Thread.sleep(OPTIMISTIC_LOCKING_COOLDOWN_MS);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+            if(nodeGroup.isEmpty()) {
+                return false;
+            } else {
+                return deleteExistingNode(connection, host, nodeGroup);
             }
+        } catch (SQLException | IOException exception) {
+            LOG.error("Postgresql node registry", "deleteNode", exception);
+            throw new RuntimeException(exception);
         }
     }
 

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
@@ -86,10 +86,6 @@ public class PostgresNodeGroup extends NodeGroup {
             statement.setString(2, nodesToJson());
 
             statement.executeUpdate();
-//            if (statement.executeUpdate() == 0) {
-//                //No rows updated
-//                throw new VersionChangedException();
-//            }
         } finally {
             long end = System.currentTimeMillis();
             LOG.info("node group insert:time", Long.toString(end - start));
@@ -103,9 +99,6 @@ public class PostgresNodeGroup extends NodeGroup {
             statement.setString(2, groupId);
 
             statement.executeUpdate();
-//            if (statement.executeUpdate() == 0) {
-//                throw new VersionChangedException();
-//            }
         }finally {
             long end = System.currentTimeMillis();
             LOG.info("node group update:time", Long.toString(end - start));

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
@@ -83,7 +83,7 @@ public class PostgresNodeGroup extends NodeGroup {
             statement.setString(2, nodesToJson());
 
             if(statement.executeUpdate() == 0) {
-                throw new RuntimeException("Locking failed on insert");
+                LOG.info("Insert new PostgresNodeGroup", "conflict on insert");
             }
         } finally {
             long end = System.currentTimeMillis();

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
@@ -85,7 +85,9 @@ public class PostgresNodeGroup extends NodeGroup {
             statement.setString(1, groupId);
             statement.setString(2, nodesToJson());
 
-            statement.executeUpdate();
+            if(statement.executeUpdate() == 0) {
+                throw new RuntimeException("Locking failed on insert");
+            }
         } finally {
             long end = System.currentTimeMillis();
             LOG.info("node group insert:time", Long.toString(end - start));
@@ -98,7 +100,9 @@ public class PostgresNodeGroup extends NodeGroup {
             statement.setString(1, nodesToJson());
             statement.setString(2, groupId);
 
-            statement.executeUpdate();
+            if(statement.executeUpdate() == 0) {
+                throw new RuntimeException("Locking failed on update");
+            }
         }finally {
             long end = System.currentTimeMillis();
             LOG.info("node group update:time", Long.toString(end - start));
@@ -110,7 +114,10 @@ public class PostgresNodeGroup extends NodeGroup {
         try (PreparedStatement statement = connection.prepareStatement(QUERY_DELETE_GROUP)) {
             statement.setString(1, groupId);
             statement.setInt(2, version);
-            statement.executeUpdate();
+
+            if(statement.executeUpdate() == 0) {
+                throw new RuntimeException("Locking failed on delete");
+            }
 
         }finally {
             long end = System.currentTimeMillis();

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroup.java
@@ -28,19 +28,16 @@ public class PostgresNodeGroup extends NodeGroup {
                     "?::JSON, " +
                     "0 " +
                     ")" +
-                    "ON CONFLICT DO NOTHING; " +
-            "COMMIT WORK;";
+                    "ON CONFLICT DO NOTHING; ";
     private static final String QUERY_UPDATE_GROUP =
             "UPDATE registry SET " +
                     "entry = ?::JSON , " +
                     "version = registry.version + 1 " +
                     "WHERE " +
                     "registry.group_id = ? " +
-                    "; " +
-            "COMMIT WORK;";
+                    "; ";
     private static final String QUERY_DELETE_GROUP =
-        "DELETE from registry where group_id = ? and version = ? ;" +
-        "COMMIT WORK;";
+        "DELETE from registry where group_id = ? and version = ? ;";
 
     public static PostgresNodeGroup createNodeGroup(final ResultSet rs) throws SQLException, IOException {
         final String entry = rs.getString("entry");

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorage.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorage.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PostgresNodeGroupStorage {
+    private static final String QUERY_BEGIN_WORK = "BEGIN WORK;";
     private static final String QUERY_GET_GROUP_BY_ID = "SELECT group_id, entry, version FROM registry where group_id = ? FOR UPDATE;";
     private static final String QUERY_GET_ALL_GROUPS = "SELECT group_id, entry, version FROM registry ORDER BY group_id";
 
@@ -16,7 +17,7 @@ public class PostgresNodeGroupStorage {
 
     PostgresNodeGroup getNodeGroup(final Connection connection, final String groupId) throws SQLException, IOException {
 
-        try(PreparedStatement beginStatement = connection.prepareStatement("BEGIN WORK;")) {
+        try(PreparedStatement beginStatement = connection.prepareStatement(QUERY_BEGIN_WORK)) {
             beginStatement.execute();
 
             try (PreparedStatement statement = connection.prepareStatement(QUERY_GET_GROUP_BY_ID)) {

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorage.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorage.java
@@ -11,8 +11,8 @@ import java.util.List;
 public class PostgresNodeGroupStorage {
     private static final String QUERY_BEGIN_WORK = "BEGIN WORK;";
     private static final String QUERY_GET_GROUP_BY_ID_FOR_UPDATE = "SELECT group_id, entry, version FROM registry where group_id = ? FOR UPDATE;";
-    private static final String QUERY_GET_GROUP_BY_ID = "SELECT group_id, entry, version FROM registry where group_id = ?;";
-    private static final String QUERY_GET_ALL_GROUPS = "SELECT group_id, entry, version FROM registry ORDER BY group_id";
+    private static final String QUERY_READ_GROUP_BY_ID = "SELECT group_id, entry, version FROM registry where group_id = ?;";
+    private static final String QUERY_READ_ALL_GROUPS = "SELECT group_id, entry, version FROM registry ORDER BY group_id";
 
     PostgresNodeGroupStorage() { }
 
@@ -37,7 +37,7 @@ public class PostgresNodeGroupStorage {
     }
 
     PostgresNodeGroup readNodeGroup(final Connection connection, final String groupId) throws SQLException, IOException {
-            try (PreparedStatement statement = connection.prepareStatement(QUERY_GET_GROUP_BY_ID)) {
+            try (PreparedStatement statement = connection.prepareStatement(QUERY_READ_GROUP_BY_ID)) {
                 statement.setString(1, groupId);
 
                 try (ResultSet rs = statement.executeQuery()) {
@@ -50,9 +50,9 @@ public class PostgresNodeGroupStorage {
             }
     }
 
-    List<PostgresNodeGroup> getNodeGroups(final Connection connection, final List<String> groupIds) throws SQLException, IOException {
+    List<PostgresNodeGroup> readNodeGroups(final Connection connection, final List<String> groupIds) throws SQLException, IOException {
         if (groupIds == null || groupIds.isEmpty()) {
-            return getAllNodeGroups(connection);
+            return readAllNodeGroups(connection);
         }
 
         final List<PostgresNodeGroup> list = new ArrayList<>();
@@ -62,9 +62,9 @@ public class PostgresNodeGroupStorage {
         return list;
     }
 
-    private List<PostgresNodeGroup> getAllNodeGroups(final Connection connection) throws SQLException, IOException {
+    private List<PostgresNodeGroup> readAllNodeGroups(final Connection connection) throws SQLException, IOException {
         List<PostgresNodeGroup> groups;
-        try (PreparedStatement statement = connection.prepareStatement(QUERY_GET_ALL_GROUPS)) {
+        try (PreparedStatement statement = connection.prepareStatement(QUERY_READ_ALL_GROUPS)) {
             groups = new ArrayList<>();
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/VersionChangedException.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/VersionChangedException.java
@@ -1,4 +1,0 @@
-package com.tesco.aqueduct.registry.postgres;
-
-public class VersionChangedException extends RuntimeException {
-}

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
@@ -4,12 +4,13 @@ import com.tesco.aqueduct.registry.model.Node
 import spock.lang.Specification
 
 import javax.sql.DataSource
+import java.sql.Connection
 import java.time.Duration
 
 class PostgreSQLNodeRegistrySpec extends Specification {
 
 	def "New node can register"() {
-		given: "a mock node group factory"
+		given: "a mock node group"
 		def cloudUrl = new URL("http://cloud.url")
 		def mockNodeGroup = Mock(PostgresNodeGroup)
 
@@ -17,8 +18,14 @@ class PostgreSQLNodeRegistrySpec extends Specification {
 		def mockNodeGroupFactory = Mock(PostgresNodeGroupStorage)
 		1 * mockNodeGroupFactory.getNodeGroup(_, _) >> mockNodeGroup
 
-		and: "a node registry"
+		and: "a mock data source"
 		def dataSourceMock = Mock(DataSource)
+		def mockConnection = Mock(Connection)
+		1 * dataSourceMock.getConnection() >> mockConnection
+		1 * mockConnection.setAutoCommit(false)
+
+		and: "a node registry"
+
 		def offlineDelta = Duration.ofMinutes(5)
 		def registry = new PostgreSQLNodeRegistry(dataSourceMock, cloudUrl, offlineDelta, mockNodeGroupFactory)
 
@@ -28,7 +35,7 @@ class PostgreSQLNodeRegistrySpec extends Specification {
 		when: "registering the node"
 		def result = registry.register(testNode)
 
-		then: "we cloud url is returned"
+		then: "the cloud url is returned"
 		result == [cloudUrl]
 	}
 }

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupSpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupSpec.groovy
@@ -34,28 +34,6 @@ class PostgresNodeGroupSpec extends Specification {
         statement.contains("UPDATE")
     }
 
-    def "If an update fails, then throw an exception"() {
-        given: "a failing SQL connection"
-        def connection = Mock(Connection) {
-            1 * prepareStatement(_) >> Mock(PreparedStatement) {
-                1 * executeUpdate() >> 0
-            }
-        }
-
-        and: "a PostgresNodeGroup"
-        Node n1 = Node.builder()
-            .localUrl(new URL("http://node-1"))
-            .pipe(["v":"1.0"])
-            .build()
-        def group = new PostgresNodeGroup("test-id", 99, [n1])
-
-        when: "we update the node group"
-        group.persist(connection)
-
-        then: "a Version Changed Exception is thrown"
-        thrown(VersionChangedException)
-    }
-
     def "can delete groups"() {
         String statement
 
@@ -81,28 +59,6 @@ class PostgresNodeGroupSpec extends Specification {
 
         then: "a statement has been run against the SQL connection"
         statement.contains("DELETE")
-    }
-
-    def "If a delete fails, then throw an exception"() {
-        given: "a failing SQL connection"
-        def connection = Mock(Connection) {
-            1 * prepareStatement(_) >> Mock(PreparedStatement) {
-                1 * executeUpdate() >> 0
-            }
-        }
-
-        and: "a PostgresNodeGroup"
-        Node n1 = Node.builder()
-            .localUrl(new URL("http://node-1"))
-            .pipe(["v":"1.0"])
-            .build()
-        def group = new PostgresNodeGroup("test-id", 99, [n1])
-
-        when: "we delete the node group"
-        group.delete(connection)
-
-        then: "a Version Changed Exception is thrown"
-        thrown(VersionChangedException)
     }
 
     def "can insert groups"() {
@@ -131,27 +87,5 @@ class PostgresNodeGroupSpec extends Specification {
 
         then: "a statement has been run against the SQL connection"
         statement.contains("INSERT")
-    }
-
-    def "If an insert fails, then throw an exception"() {
-        given: "a failing SQL connection"
-        def connection = Mock(Connection) {
-            1 * prepareStatement(_) >> Mock(PreparedStatement) {
-                1 * executeUpdate() >> 0
-            }
-        }
-
-        and: "a PostgresNodeGroup"
-        Node n1 = Node.builder()
-            .localUrl(new URL("http://node-1"))
-            .pipe(["v":"1.0"])
-            .build()
-        def group = new PostgresNodeGroup("test-id", 99, [n1])
-
-        when: "we insert the node group"
-        group.persist(connection)
-
-        then: "a Version Changed Exception is thrown"
-        thrown(VersionChangedException)
     }
 }

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
@@ -13,12 +13,6 @@ class PostgresNodeGroupStorageSpec extends Specification {
 
 		given: "a SQL connection"
 		def connection = Mock(Connection) {
-			1 * prepareStatement("BEGIN WORK;") >> {
-				return Mock(PreparedStatement) {
-					1 * execute() >> true
-				}
-			}
-
 			1 * prepareStatement(_) >> {
 				statement = it
 				return Mock(PreparedStatement) {

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
@@ -64,12 +64,6 @@ class PostgresNodeGroupStorageSpec extends Specification {
 
 		given: "a SQL connection"
 		def connection = Mock(Connection) {
-			1 * prepareStatement("BEGIN WORK;") >> {
-				return Mock(PreparedStatement) {
-					1 * execute() >> true
-				}
-			}
-
 			1 * prepareStatement(_) >> {
 				statement = it
 				return Mock(PreparedStatement) {

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
@@ -99,7 +99,7 @@ class PostgresNodeGroupStorageSpec extends Specification {
 		def PostgresNodeGroupStorage = new PostgresNodeGroupStorage()
 
 		when: "I ask the PostgresNodeGroupStorage to get a list of NodeGroups"
-		def result = PostgresNodeGroupStorage.getNodeGroups(connection, ["test-group-id"])
+		def result = PostgresNodeGroupStorage.readNodeGroups(connection, ["test-group-id"])
 
 		then: "then a select statement is run"
 		statement.contains("SELECT")
@@ -144,7 +144,7 @@ class PostgresNodeGroupStorageSpec extends Specification {
 		def PostgresNodeGroupStorage = new PostgresNodeGroupStorage()
 
 		when: "I ask the PostgresNodeGroupStorage to get a list of NodeGroups, providing no ids"
-		def result = PostgresNodeGroupStorage.getNodeGroups(connection, [])
+		def result = PostgresNodeGroupStorage.readNodeGroups(connection, [])
 
 		then: "then a select statement is run"
 		statement.contains("SELECT")

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgresNodeGroupStorageSpec.groovy
@@ -13,6 +13,12 @@ class PostgresNodeGroupStorageSpec extends Specification {
 
 		given: "a SQL connection"
 		def connection = Mock(Connection) {
+			1 * prepareStatement("BEGIN WORK;") >> {
+				return Mock(PreparedStatement) {
+					1 * execute() >> true
+				}
+			}
+
 			1 * prepareStatement(_) >> {
 				statement = it
 				return Mock(PreparedStatement) {
@@ -58,6 +64,12 @@ class PostgresNodeGroupStorageSpec extends Specification {
 
 		given: "a SQL connection"
 		def connection = Mock(Connection) {
+			1 * prepareStatement("BEGIN WORK;") >> {
+				return Mock(PreparedStatement) {
+					1 * execute() >> true
+				}
+			}
+
 			1 * prepareStatement(_) >> {
 				statement = it
 				return Mock(PreparedStatement) {


### PR DESCRIPTION
Adds row level locking on writes to the registry, replacing application level optimistic locking.

Removes unused Measure annotations.