### PR TITLE
 #82 AS/SL:

### DIFF
--- a/pipe-micronaut-common/src/main/java/com/tesco/aqueduct/pipe/metrics/MetricsInterceptor.java
+++ b/pipe-micronaut-common/src/main/java/com/tesco/aqueduct/pipe/metrics/MetricsInterceptor.java
@@ -23,7 +23,9 @@ public class MetricsInterceptor implements MethodInterceptor<Object, Object> {
             MDC.put("class", context.getDeclaringType().getCanonicalName());
             MDC.put("method", context.getMethodName());
             LOG.info(null);
-            MDC.clear();
+            MDC.remove("timeMs");
+            MDC.remove("class");
+            MDC.remove("method");
         }
     }
 }


### PR DESCRIPTION
- Remove specific MDC keys after logging within MetricsInterceptor instead of clearing it all together
This is done to avoid clearing any other MDC keys for ex: trace_id