### PR TITLE
Change leak detection threshold to 60 seconds

### DIFF
--- a/pipe-http-server-cloud/configuration/application.yml
+++ b/pipe-http-server-cloud/configuration/application.yml
@@ -42,7 +42,7 @@ datasources:
     driver-class-name: org.postgresql.Driver
     maximum-pool-size: 6
     max-lifetime: 900000
-    leak-detection-threshold: 30000
+    leak-detection-threshold: 35000
 
 authentication:
   identity:

--- a/pipe-http-server-cloud/configuration/application.yml
+++ b/pipe-http-server-cloud/configuration/application.yml
@@ -42,7 +42,7 @@ datasources:
     driver-class-name: org.postgresql.Driver
     maximum-pool-size: 6
     max-lifetime: 900000
-    leak-detection-threshold: 35000
+    leak-detection-threshold: 60000
 
 authentication:
   identity:

--- a/pipe-http-server-cloud/configuration/application.yml
+++ b/pipe-http-server-cloud/configuration/application.yml
@@ -41,7 +41,7 @@ datasources:
     password: "${POSTGRE_PASSWORD}"
     driver-class-name: org.postgresql.Driver
     maximum-pool-size: 6
-    max-lifetime: 900000
+    max-lifetime: 600000
     leak-detection-threshold: 60000
 
 authentication:


### PR DESCRIPTION
Change leak detection threshold to 35 seconds to remove error logs appearing due to compaction running