### PR TITLE
Adding more error logging

### DIFF
--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenProvider.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/issuer/IdentityIssueTokenProvider.java
@@ -56,6 +56,8 @@ public class IdentityIssueTokenProvider implements TokenProvider {
             if (exception.getStatus().getCode() > 499) {
                 throw new IdentityServiceUnavailableException("Unexpected error from Identity with status - " + exception.getStatus());
             }
+        } else {
+            LOG.error("retrieveIdentityToken", "Unexpected error from Identity", error);
         }
     }
 

--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/validator/IdentityTokenValidator.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/identity/validator/IdentityTokenValidator.java
@@ -78,10 +78,12 @@ public class IdentityTokenValidator implements TokenValidator {
     private void handleError(Throwable error) {
         if (error instanceof HttpClientResponseException) {
             HttpClientResponseException exception = (HttpClientResponseException) error;
-            LOG.error("validateToken", "Identity response error: ", exception);
+            LOG.error("validateToken", "Identity response error", exception);
             if (exception.getStatus().getCode() > 499) {
                 throw new IdentityServiceUnavailableException("Unexpected error from Identity with status - " + exception.getStatus());
             }
+        } else {
+            LOG.error("validateToken", "Unexpected error from Identity", error);
         }
     }
 

--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/location/CloudLocationResolver.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/location/CloudLocationResolver.java
@@ -36,6 +36,9 @@ public class CloudLocationResolver implements LocationResolver {
             } else {
                 throw exception;
             }
+        } catch (final Exception exception) {
+            LOG.error("resolve", "Unexpected error from location", exception);
+            throw exception;
         }
     }
 


### PR DESCRIPTION
Added logging for any errors happening during client calls to report which client is throwing error.
We were logging only for HttpClienResponseException but on production we have seen some errors like SSLHandshake that we suspect are occurring while trying to connect to external services. Improved logging now should report which service throws these errors.