### PR TITLE
Proof of concept for storing messages in memory with compression and generation of json patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,14 +27,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.projectlombok:lombok:1.18.2"
-        classpath "io.franzbecker:gradle-lombok:1.14"
+        classpath "io.franzbecker:gradle-lombok:4.0.0"
         classpath "com.github.jengelman.gradle.plugins:shadow:5.0.0"
         classpath "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.5"
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE'
         classpath "pl.allegro.tech.build:axion-release-plugin:1.10.0"
         classpath "com.adarshr:gradle-test-logger-plugin:1.6.0"
-        classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.7.1"
+        classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.4.5"
         classpath 'org.owasp:dependency-check-gradle:5.0.0-M3.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
     }
@@ -70,6 +69,10 @@ idea.project.settings {
 }
 
 allprojects {
+    ext {
+        groovyVersion = "2.5.10"
+        spockVersion = "1.3-groovy-2.5"
+    }
     repositories {
         jcenter()
         mavenCentral()
@@ -81,7 +84,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     jacoco {
-        toolVersion = "0.8.4"
+        toolVersion = "0.8.5"
         reportsDir = file("${rootProject.buildDir}/reports/jacoco/${project.name}")
     }
 }
@@ -97,7 +100,7 @@ subprojects {
     apply plugin: 'pmd'
 
     lombok {
-        version = "1.18.2"
+        version = "1.18.12"
     }
 
     task packageSources(type: Jar, dependsOn: 'classes') {
@@ -117,8 +120,6 @@ subprojects {
                 }
 
                 // order is important
-                compileOnly 'org.projectlombok:lombok:1.18.2'
-                annotationProcessor 'org.projectlombok:lombok:1.18.2'
                 compileOnly 'io.micronaut:micronaut-inject-java'
                 annotationProcessor 'io.micronaut:micronaut-inject-java'
 
@@ -134,7 +135,7 @@ subprojects {
                 implementation 'io.micronaut:micronaut-inject'
                 implementation 'io.micronaut:micronaut-runtime'
 
-                testCompileOnly 'io.micronaut:micronaut-inject-groovy'
+                testCompile 'io.micronaut:micronaut-inject-groovy'
                 testCompile 'io.micronaut.test:micronaut-test-spock:1.0.1'
                 testCompile 'io.micronaut.test:micronaut-test-junit5:1.0.1'
             }
@@ -175,7 +176,7 @@ subprojects {
     }
 
     pmd {
-        toolVersion = '5.8.1'
+        toolVersion = '6.26.0'
         ignoreFailures = true
 
         ruleSets = [
@@ -224,8 +225,9 @@ subprojects {
     dependencies {
 
         // Groovy and Spock dependencies
-        testCompile 'org.codehaus.groovy:groovy-all:2.5.5'
-        testCompile 'org.spockframework:spock-core:1.2-groovy-2.5'
+        testCompile "org.codehaus.groovy:groovy:$groovyVersion" // added explicitly as was overridden somewhere
+        testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
+        testCompile "org.spockframework:spock-core:$spockVersion"
         testCompile "io.rest-assured:rest-assured:3.1.1"
 
         testCompile 'com.stehno.ersatz:ersatz:1.9.0:safe@jar'
@@ -236,10 +238,6 @@ subprojects {
         
         testRuntime 'net.bytebuddy:byte-buddy:1.9.6' // allows mocking of classes (in addition to interfaces)
         testRuntime 'org.objenesis:objenesis:2.6'    // allows mocking of classes without default constructor (together with CGLIB)
-
-        testCompile "io.micronaut:micronaut-inject-groovy"
-        testAnnotationProcessor "io.micronaut:micronaut-inject-groovy" // allows testing using MicronautTest framework
-        testCompile "io.micronaut.test:micronaut-test-spock"
     }
 
     // add -parameters to java compile have Jackson happy
@@ -295,9 +293,11 @@ task jacocoMerge(type: JacocoMerge) {
 task jacocoRootReport(type: JacocoReport) {
     onlyIf = { true }
     executionData(jacocoMerge.executionData)
-    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
-    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories = files(subprojects.sourceSets.main.output)
+
+    additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories.setFrom files(subprojects.sourceSets.main.output)
+
     reports {
         xml.enabled = false
         csv.enabled = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/Message.java
+++ b/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/Message.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.Data;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.time.ZonedDateTime;
 
 @Data
-@Wither
+@With
 public class Message {
     private final String type;
     private final String key;

--- a/pipe-storage-test/build.gradle
+++ b/pipe-storage-test/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compile project(":pipe-api")
 
-    compile 'org.codehaus.groovy:groovy-all:2.5.5'
-    compile 'org.spockframework:spock-core:1.2-groovy-2.5'
+    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.spockframework:spock-core:$spockVersion"
 }
 
 addPublish()


### PR DESCRIPTION
# In memory repository of messages with optional patching on write and optional compression.

Reasonable memory efficiency is achieved by storing messages with compressed byte arrays and decompressing them at read time.

Appending, finding and scanning efficiency is achieved by using a SkipList as a map, to map offsets to messages.
Patching is relatively good as we track previous offset in a hashmap.
This approach could also support deletions if needed.

- can compress data in memory
 - supports different codecs (only gzip at the moment)
 - automatically decompress data on read
 - smart in deciding should it encode or not per message (encoded might be bigger) with a ratio
 - provide JSON patch where possible and sensible for data
 - calculate patch on write, saving it only if it is smaller enough (with a ratio)
 - efficient for writes - theoretically O(log N) practically constant for current use case
 - efficient for finding indexes (or next available value if offset does not exist) - O(log N)
 - efficient for full scans - once element is found it is O(1) to get the next one
 - optimised for reading with patches - patches are generated during write time and stored compressed
 - relatively good patching time - as we always know what the previous offset of a key was we can quickly find it and generate a patch
 

## Gzipping and patching

### AdoptOpenJDK 14.0.2
 `-Xmx12g -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC`

TODO: results

### AdoptOpenJDK 1.8.0_252
With default settings.

```
Inserted 5191680 messages in 1132.653 seconds. (20 minutes!)
Heap dump - not done
```

![image](https://user-images.githubusercontent.com/720999/90627270-ae046100-e213-11ea-909e-86d5887d9ab2.png)


# Observations
Observation done on dump of representatitive live data - 10gb of json, 5mln messages.

- generation of patches is expensive, it takes 20 minutes to get them all
- without patches it is 5x faster - less than 4 minutes in worst ase
- if possible it would be good to generate patches during publish time and save them in database
- both patch and gzip can generate data bigger than input, especially patch has huge cost so if it does not bring much value it should not be used