### PR TITLE
Sort registry tree by provider status instead of till pipe state

### DIFF
--- a/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
+++ b/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
@@ -41,8 +41,6 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
     private static final String USERNAME_ENCODED_CREDENTIALS = "${USERNAME}:${PASSWORD}".bytes.encodeBase64().toString()
     private static final String USERNAME_TWO = "username-two"
     private static final String PASSWORD_TWO = "password-two"
-    private static final int SERVER_TIMEOUT_MS = 5000
-    private static final int SERVER_SLEEP_TIME_MS = 500
     private static final String NODE_A_CLIENT_UID = "random"
 
     private static final String clientId = UUID.randomUUID().toString()
@@ -61,8 +59,6 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
     SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance()
 
     @AutoCleanup Sql sql
-
-    private GzipCodec gzip = new GzipCodec();
 
     DataSource dataSource
     NodeRegistry registry
@@ -158,11 +154,13 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
                 """
             )
             )
+            .mainClass(EmbeddedServer)
             .build()
             .registerSingleton(NodeRegistry, registry)
             .registerSingleton(Reader, reader)
             .registerSingleton(NodeRequestStorage, nodeRequestStorage)
-            .start()
+
+        context.start()
 
         identityMock.clearExpectations()
 
@@ -170,13 +168,7 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
 
         RestAssured.port = server.port
         server.start()
-        def time = 0
-        while (!server.isRunning() && time < SERVER_TIMEOUT_MS) {
-            println("Server not yet running...")
-            sleep SERVER_SLEEP_TIME_MS
-            time += SERVER_SLEEP_TIME_MS
-        }
-        println("Test setup complete")
+
         TestAppender.clearEvents()
     }
 

--- a/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
+++ b/pipe-http-server-cloud/src/integration/groovy/NodeRegistryControllerV2IntegrationSpec.groovy
@@ -409,19 +409,19 @@ class NodeRegistryControllerV2IntegrationSpec extends Specification {
 
         then: "Nodes are sorted as expected"
         request.then().body(
-            "followers[0].localUrl", equalTo("http://1.1.1.3:0003"),
-            "followers[1].localUrl", equalTo("http://1.1.1.4:0004"),
-            "followers[2].localUrl", equalTo("http://1.1.1.5:0005"),
+            "followers[0].localUrl", equalTo("http://1.1.1.4:0004"),
+            "followers[1].localUrl", equalTo("http://1.1.1.5:0005"),
+            "followers[2].localUrl", equalTo("http://1.1.1.3:0003"),
             "followers[3].localUrl", equalTo("http://1.1.1.1:0001"),
             "followers[4].localUrl", equalTo("http://1.1.1.2:0002"),
             "followers[5].localUrl", equalTo("http://1.1.1.6:0006"),
             //following lists
             "followers[0].requestedToFollow", equalTo(["http://cloud.pipe"]),
-            "followers[1].requestedToFollow", equalTo(["http://1.1.1.3:0003", "http://cloud.pipe"]),
-            "followers[2].requestedToFollow", equalTo(["http://1.1.1.3:0003", "http://cloud.pipe"]),
-            "followers[3].requestedToFollow", equalTo(["http://1.1.1.4:0004", "http://1.1.1.3:0003", "http://cloud.pipe"]),
-            "followers[4].requestedToFollow", equalTo(["http://1.1.1.4:0004", "http://1.1.1.3:0003", "http://cloud.pipe"]),
-            "followers[5].requestedToFollow", equalTo(["http://1.1.1.5:0005", "http://1.1.1.3:0003", "http://cloud.pipe"]),
+            "followers[1].requestedToFollow", equalTo(["http://1.1.1.4:0004", "http://cloud.pipe"]),
+            "followers[2].requestedToFollow", equalTo(["http://1.1.1.4:0004", "http://cloud.pipe"]),
+            "followers[3].requestedToFollow", equalTo(["http://1.1.1.5:0005", "http://1.1.1.4:0004", "http://cloud.pipe"]),
+            "followers[4].requestedToFollow", equalTo(["http://1.1.1.5:0005", "http://1.1.1.4:0004", "http://cloud.pipe"]),
+            "followers[5].requestedToFollow", equalTo(["http://1.1.1.3:0003", "http://1.1.1.4:0004", "http://cloud.pipe"]),
         )
     }
 

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/Status.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/Status.java
@@ -1,9 +1,9 @@
 package com.tesco.aqueduct.registry.model;
 
 public enum Status {
-    PENDING,
-    INITIALISING,
+    OK,
     FOLLOWING,
-    OFFLINE,
-    OK
+    INITIALISING,
+    PENDING,
+    OFFLINE
 }

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
@@ -107,18 +107,7 @@ public class SubNodeGroup {
 
     public void sortNodes(URL cloudUrl) {
         nodes.sort(comparing(Node::getStatus));
-        nodes.sort(this::comparingOfflineStatus);
         updateGetFollowing(cloudUrl);
-    }
-
-    private int comparingOfflineStatus(Node node1, Node node2) {
-        if (node1.isOffline() && !node2.isOffline()) {
-            return 1;
-        } else if (!node1.isOffline() && node2.isOffline()) {
-            return -1;
-        } else {
-            return 0;
-        }
     }
 
     public Optional<Node> findAndUpdate(Node nodeToRegister) {

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/SubNodeGroup.java
@@ -106,7 +106,7 @@ public class SubNodeGroup {
     }
 
     public void sortNodes(URL cloudUrl) {
-        nodes.sort(comparing(Node::getPipeState));
+        nodes.sort(comparing(Node::getStatus));
         nodes.sort(this::comparingOfflineStatus);
         updateGetFollowing(cloudUrl);
     }

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
@@ -199,7 +199,7 @@ class NodeGroupSpec extends Specification {
         group.subGroups.get(1).nodes.get(0).requestedToFollow == [cloudUrl]
     }
 
-    def "Nodes are sorted based on status"() {
+    def "Nodes are sorted based on provider status"() {
         given: "a cloud url"
         URL cloudUrl = new URL("http://cloud")
 
@@ -253,14 +253,14 @@ class NodeGroupSpec extends Specification {
         group.sortNodes(cloudUrl)
 
         then: "nodes that are offline are sorted to be leaves"
-        group.subGroups.get(0).nodes.stream().map({ n -> n.getLocalUrl() }).collect() == [n3Url, n4Url, n5Url, n1Url, n2Url, n6Url]
+        group.subGroups.get(0).nodes.stream().map({ n -> n.getLocalUrl() }).collect() == [n3Url, n5Url, n4Url, n1Url, n2Url, n6Url]
 
         group.subGroups.get(0).nodes.get(0).requestedToFollow == [cloudUrl]
         group.subGroups.get(0).nodes.get(1).requestedToFollow == [n3Url, cloudUrl]
         group.subGroups.get(0).nodes.get(2).requestedToFollow == [n3Url, cloudUrl]
-        group.subGroups.get(0).nodes.get(3).requestedToFollow == [n4Url, n3Url, cloudUrl]
-        group.subGroups.get(0).nodes.get(4).requestedToFollow == [n4Url, n3Url, cloudUrl]
-        group.subGroups.get(0).nodes.get(5).requestedToFollow == [n5Url, n3Url, cloudUrl]
+        group.subGroups.get(0).nodes.get(3).requestedToFollow == [n5Url, n3Url, cloudUrl]
+        group.subGroups.get(0).nodes.get(4).requestedToFollow == [n5Url, n3Url, cloudUrl]
+        group.subGroups.get(0).nodes.get(5).requestedToFollow == [n4Url, n3Url, cloudUrl]
     }
 
     def "Nodes maintain sort order when none are offline"() {
@@ -316,8 +316,8 @@ class NodeGroupSpec extends Specification {
         when: "sort based on status is called"
         group.sortNodes(cloudUrl)
 
-        then: "the sort order is unchanged"
-        group.subGroups.get(0).nodes == [n1, n2, n3, n4, n5, n6]
+        then: "the sort is based on provider status"
+        group.subGroups.get(0).nodes.stream().map({ n -> n.getLocalUrl() }).collect() == [n1Url, n3Url, n6Url, n5Url, n2Url, n4Url]
     }
 
     def "NodeGroup nodes json format is correct"() {

--- a/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
+++ b/registry-core/src/test/groovy/com/tesco/aqueduct/registry/model/NodeGroupSpec.groovy
@@ -316,7 +316,7 @@ class NodeGroupSpec extends Specification {
         when: "sort based on status is called"
         group.sortNodes(cloudUrl)
 
-        then: "the sort is based on provider status"
+        then: "the sort is based on status"
         group.subGroups.get(0).nodes.stream().map({ n -> n.getLocalUrl() }).collect() == [n1Url, n3Url, n6Url, n5Url, n2Url, n4Url]
     }
 

--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -97,7 +97,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         followers.size() == 1
     }
 
-    def "registry marks nodes offline and sorts based on status and pipeState"() {
+    def "registry marks nodes offline and sorts based on status and status"() {
         given: "a registry with a short offline delta"
         registry = new PostgreSQLNodeRegistry(dataSource, cloudURL, Duration.ofSeconds(5))
 
@@ -146,11 +146,11 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
 
         then: "nodes are marked as offline and sorted accordingly"
         followers[0].getLocalUrl() == url3
-        followers[1].getLocalUrl() == url5
-        followers[2].getLocalUrl() == url4
-        followers[3].getLocalUrl() == url2
-        followers[4].getLocalUrl() == url6
-        followers[5].getLocalUrl() == url1
+        followers[1].getLocalUrl() == url4
+        followers[2].getLocalUrl() == url5
+        followers[3].getLocalUrl() == url1
+        followers[4].getLocalUrl() == url2
+        followers[5].getLocalUrl() == url6
 
         followers[0].status == FOLLOWING
         followers[1].status == FOLLOWING
@@ -162,9 +162,9 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         followers[0].requestedToFollow == [cloudURL]
         followers[1].requestedToFollow == [url3, cloudURL]
         followers[2].requestedToFollow == [url3, cloudURL]
-        followers[3].requestedToFollow == [url5, url3, cloudURL]
-        followers[4].requestedToFollow == [url5, url3, cloudURL]
-        followers[5].requestedToFollow == [url4, url3, cloudURL]
+        followers[3].requestedToFollow == [url4, url3, cloudURL]
+        followers[4].requestedToFollow == [url4, url3, cloudURL]
+        followers[5].requestedToFollow == [url5, url3, cloudURL]
     }
 
     @Unroll
@@ -267,8 +267,8 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         registerNode("x", "http://first", 0, PENDING, [])
 
         then: "It's state is updated"
-        List<Node> nodesState = registry.getSummary(0, INITIALISING, ["x"]).followers
-        nodesState.toList().get(0).status == PENDING
+        List<Node> nodes = registry.getSummary(0, INITIALISING, ["x"]).followers
+        nodes.toList().find { it.getLocalUrl() == "http://first" }.status == PENDING
     }
 
     @Unroll

--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -97,7 +97,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         followers.size() == 1
     }
 
-    def "registry marks nodes offline and sorts based on status and status"() {
+    def "registry marks nodes offline and sorts based on status"() {
         given: "a registry with a short offline delta"
         registry = new PostgreSQLNodeRegistry(dataSource, cloudURL, Duration.ofSeconds(5))
 

--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -268,7 +268,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
 
         then: "It's state is updated"
         List<Node> nodes = registry.getSummary(0, INITIALISING, ["x"]).followers
-        nodes.toList().find { it.getLocalUrl() == "http://first" }.status == PENDING
+        nodes.toList().find{ it.localUrl == new URL("http://first") }.status == PENDING
     }
 
     @Unroll


### PR DESCRIPTION
By sorting by provider status it will cause no rebalancing when data is published in the cloud