### PR TITLE
Pass codec

### DIFF
--- a/pipe-codec/src/main/java/com/tesco/aqueduct/pipe/codec/BrotliCodec.java
+++ b/pipe-codec/src/main/java/com/tesco/aqueduct/pipe/codec/BrotliCodec.java
@@ -5,6 +5,7 @@ import com.nixxcode.jvmbrotli.dec.BrotliInputStream;
 import com.nixxcode.jvmbrotli.enc.BrotliOutputStream;
 import com.nixxcode.jvmbrotli.enc.Encoder;
 import com.tesco.aqueduct.pipe.logger.PipeLogger;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Value;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+@Primary
 @Singleton
 public class BrotliCodec implements Codec {
 

--- a/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
+++ b/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
@@ -1,7 +1,7 @@
 package com.tesco.aqueduct.pipe.http.client;
 
 import com.tesco.aqueduct.pipe.api.*;
-import com.tesco.aqueduct.pipe.codec.BrotliCodec;
+import com.tesco.aqueduct.pipe.codec.Codec;
 import io.micronaut.http.HttpResponse;
 
 import javax.annotation.Nullable;
@@ -18,12 +18,12 @@ public class HttpPipeClient implements Reader {
 
     private final InternalHttpPipeClient client;
 
-    private final BrotliCodec brotliCodec;
+    private final Codec codec;
 
     @Inject
-    public HttpPipeClient(final InternalHttpPipeClient client, final BrotliCodec brotliCodec) {
+    public HttpPipeClient(final InternalHttpPipeClient client, final Codec codec) {
         this.client = client;
-        this.brotliCodec = brotliCodec;
+        this.codec = codec;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class HttpPipeClient implements Reader {
 
         if (response.getHeaders().contains(X_CONTENT_ENCODING) &&
                 response.getHeaders().get(X_CONTENT_ENCODING).contains("br")) {
-            responseBody = brotliCodec.decode(response.body());
+            responseBody = codec.decode(response.body());
         } else {
             responseBody = response.body();
         }


### PR DESCRIPTION
We've noticed that on operating systems where Brotli isn't supported it still tries to initialise and load the Brotli library. We this change it should load either Gzip or brotli depending on the platform it runs on