### PR TITLE
Split cluster-id query to a separate call

### DIFF
--- a/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
+++ b/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
@@ -485,8 +485,9 @@ class PostgresqlStorageIntegrationSpec extends StorageSpec {
         when: 'reading with a different cluster'
         def messageResults = storage.read(["type2", "type3"], 0, ["cluster3"])
 
-        then: 'messages belonging to cluster1 are returned'
+        then: 'messages are not returned, and no exception is thrown'
         messageResults.messages.size() == 0
+        noExceptionThrown()
     }
 
     def "pipe should return messages if available from the given offset instead of empty set"() {

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -92,6 +92,7 @@ public class PostgresqlStorage implements CentralStorage {
         try(PreparedStatement statement = getClusterIdStatement(connection, clusterUuids)) {
             return runClusterIdsQuery(statement);
         } catch (SQLException exception) {
+            LOG.error("postgresql storage", "get cluster ids", exception);
             throw new RuntimeException(exception);
         }
     }
@@ -231,10 +232,8 @@ public class PostgresqlStorage implements CentralStorage {
 
     private PreparedStatement getClusterIdStatement(final Connection connection, final List<String> clusterUuids) {
         try {
-            PreparedStatement query;
             final String strClusters = String.join(",", clusterUuidsWithDefaultCluster(clusterUuids));
-
-            query = connection.prepareStatement(getClusterIdQuery());
+            PreparedStatement query = connection.prepareStatement(getClusterIdQuery());
             query.setString(1, strClusters);
             return query;
         } catch (SQLException exception) {

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -211,16 +211,13 @@ public class PostgresqlStorage implements CentralStorage {
 
     private Array runClusterIdsQuery(final PreparedStatement query) throws SQLException {
         long start = System.currentTimeMillis();
-
         try (ResultSet rs = query.executeQuery()) {
-            while (rs.next()) {
-                return rs.getArray(1);
-            }
+            rs.next();
+            return rs.getArray(1);
         } finally {
             long end = System.currentTimeMillis();
             LOG.info("runClusterIdsQuery:time", Long.toString(end - start));
         }
-        return null;
     }
 
     private PreparedStatement getLatestOffsetStatement(final Connection connection) {
@@ -241,6 +238,7 @@ public class PostgresqlStorage implements CentralStorage {
             query.setString(1, strClusters);
             return query;
         } catch (SQLException exception) {
+            LOG.error("postgresql storage", "get cluster ids statement", exception);
             throw new RuntimeException(exception);
         }
     }


### PR DESCRIPTION
Removes the need for expensive join, giving ~15% performance improvement