### PR TITLE
Use retry in ms header

### DIFF
--- a/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/HttpHeaders.java
+++ b/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/HttpHeaders.java
@@ -2,6 +2,7 @@ package com.tesco.aqueduct.pipe.api;
 
 public class HttpHeaders {
     public static final String RETRY_AFTER = "Retry-After";
+    public static final String RETRY_AFTER_MS = "Retry-After-Ms";
     public static final String GLOBAL_LATEST_OFFSET = "Global-Latest-Offset";
     public static final String PIPE_STATE = "Pipe-State";
     public static final String X_CONTENT_ENCODING = "X-Content-Encoding";

--- a/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/MessageResults.java
+++ b/pipe-api/src/main/java/com/tesco/aqueduct/pipe/api/MessageResults.java
@@ -8,7 +8,7 @@ import java.util.OptionalLong;
 @Data
 public class MessageResults {
     private final List<Message> messages;
-    private final long retryAfterSeconds;
+    private final long retryAfterMs;
     private final OptionalLong globalLatestOffset;
     private final PipeState pipeState;
 }

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
@@ -65,7 +65,7 @@ class PipeLoadBalancerIntegrationSpec extends Specification {
             .start()
 
         def brotliClient = context.getBean(InternalBrotliHttpPipeClient)
-        context.registerSingleton(new HttpPipeClient(brotliClient, brotliCodec))
+        context.registerSingleton(new HttpPipeClient(brotliClient, brotliCodec, 240))
 
         client = context.getBean(HttpPipeClient)
         loadBalancer = context.getBean(PipeLoadBalancer)

--- a/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
+++ b/pipe-http-client/src/main/java/com/tesco/aqueduct/pipe/http/client/HttpPipeClient.java
@@ -2,6 +2,7 @@ package com.tesco.aqueduct.pipe.http.client;
 
 import com.tesco.aqueduct.pipe.api.*;
 import com.tesco.aqueduct.pipe.codec.Codec;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpResponse;
 
 import javax.annotation.Nullable;
@@ -20,10 +21,17 @@ public class HttpPipeClient implements Reader {
 
     private final Codec codec;
 
+    private final long defaultRetryAfter;
+
     @Inject
-    public HttpPipeClient(final InternalHttpPipeClient client, final Codec codec) {
+    public HttpPipeClient(
+            final InternalHttpPipeClient client,
+            final Codec codec,
+            @Property(name = "persistence.read.default-retry-after") long defaultRetryAfter
+    ) {
         this.client = client;
         this.codec = codec;
+        this.defaultRetryAfter = defaultRetryAfter;
     }
 
     @Override
@@ -46,13 +54,11 @@ public class HttpPipeClient implements Reader {
 
         final long retryAfter = Optional
             .ofNullable(response.header(HttpHeaders.RETRY_AFTER_MS))
-            .map(this::checkForValidNumber)
-            .map(value -> Long.max(0, value))
+            .map(value -> checkForValidNumber(value, 1))
             .orElse(Optional
                 .ofNullable(response.header(HttpHeaders.RETRY_AFTER))
-                .map(this::checkForValidNumber)
-                .map(value -> Long.max(0, value * 1000))
-                .orElse(0L));
+                .map(value -> checkForValidNumber(value, 1000))
+                .orElse(defaultRetryAfter));
 
         return new MessageResults(
             JsonHelper.messageFromJsonArray(responseBody),
@@ -72,11 +78,11 @@ public class HttpPipeClient implements Reader {
         throw new UnsupportedOperationException("HttpPipeClient does not support this operation.");
     }
 
-    private long checkForValidNumber(String value) {
+    private long checkForValidNumber(String value, int multiplier) {
         try {
-            return Long.parseLong(value);
+            return Long.parseLong(value) > 0 ? Long.parseLong(value) * multiplier : defaultRetryAfter;
         } catch (NumberFormatException exception) {
-            return 0L;
+            return defaultRetryAfter;
         }
     }
 

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
@@ -42,6 +42,7 @@ class HttpPipeClientSpec extends Specification {
         HttpResponse<byte[]> httpResponse = new SimpleHttpResponse()
         httpResponse.body(response.bytes)
         httpResponse.headers.set(HttpHeaders.RETRY_AFTER, retry)
+        httpResponse.headers.set(HttpHeaders.RETRY_AFTER_MS, retryMs)
         httpResponse.headers.set(HttpHeaders.GLOBAL_LATEST_OFFSET, String.valueOf(0L))
         httpResponse.headers.set(HttpHeaders.PIPE_STATE, PipeState.UP_TO_DATE.name())
 
@@ -55,12 +56,14 @@ class HttpPipeClientSpec extends Specification {
         results.retryAfterMs == result
 
         where:
-        retry | result
-        ""    | 0
-        null  | 0
-        "5"   | 5
-        "-5"  | 0
-        "foo" | 0
+        retry | retryMs | result
+        ""    | ""      | 0
+        null  | null    | 0
+        "5"   | null    | 5000
+        null  | "5000"  | 5000
+        "6"   | "5000"  | 5000
+        "-5"  | "-5000" | 0
+        "foo" | "bar"   | 0
     }
 
     def "if global offset is available in the header, it should be returned in MessageResults"() {

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
@@ -52,7 +52,7 @@ class HttpPipeClientSpec extends Specification {
 
         then: "we parse the retry after if its correct or return 0 otherwise"
         results.messages.size() == 1
-        results.retryAfterSeconds == result
+        results.retryAfterMs == result
 
         where:
         retry | result

--- a/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
+++ b/pipe-http-client/src/test/groovy/com/tesco/aqueduct/pipe/http/client/HttpPipeClientSpec.groovy
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 class HttpPipeClientSpec extends Specification {
 
     InternalHttpPipeClient internalClient = Mock()
-    HttpPipeClient client = new HttpPipeClient(internalClient, new BrotliCodec(4, false))
+    HttpPipeClient client = new HttpPipeClient(internalClient, new BrotliCodec(4, false), 240)
 
     static def responseBody = """[
             {
@@ -57,13 +57,14 @@ class HttpPipeClientSpec extends Specification {
 
         where:
         retry | retryMs | result
-        ""    | ""      | 0
-        null  | null    | 0
+        ""    | ""      | 240
+        null  | null    | 240
         "5"   | null    | 5000
         null  | "5000"  | 5000
         "6"   | "5000"  | 5000
-        "-5"  | "-5000" | 0
-        "foo" | "bar"   | 0
+        "-5"  | "-5000" | 240
+        "foo" | "bar"   | 240
+        "foo" | null    | 240
     }
 
     def "if global offset is available in the header, it should be returned in MessageResults"() {

--- a/pipe-http-server-cloud/src/main/resources/application-ppe.yml
+++ b/pipe-http-server-cloud/src/main/resources/application-ppe.yml
@@ -49,7 +49,7 @@ persistence:
   read:
     limit: 2500
     max-batch-size: 1000000
-    retry-after: 120
+    retry-after: 120000
     expected-node-count: 30
     cluster-db-pool-size: 24
     read-delay-seconds: 60

--- a/pipe-http-server-cloud/src/main/resources/application-prod.yml
+++ b/pipe-http-server-cloud/src/main/resources/application-prod.yml
@@ -45,7 +45,7 @@ persistence:
   read:
     limit: 2500
     max-batch-size: 1000000
-    retry-after: 240
+    retry-after: 240000
     expected-node-count: 7000
     cluster-db-pool-size: 24
     read-delay-seconds: 60

--- a/pipe-http-server-cloud/src/main/resources/application-system_tests.yml
+++ b/pipe-http-server-cloud/src/main/resources/application-system_tests.yml
@@ -41,7 +41,7 @@ persistence:
   read:
     limit: 2500
     max-batch-size: 1000000
-    retry-after: 1
+    retry-after: 1000
     expected-node-count: 3
     cluster-db-pool-size: 72
     read-delay-seconds: 1

--- a/pipe-http-server-cloud/src/test/resources/application-integration.yml
+++ b/pipe-http-server-cloud/src/test/resources/application-integration.yml
@@ -37,7 +37,7 @@ persistence:
   read:
     limit: 1000
     max-batch-size: 2000000
-    retry-after: 10
+    retry-after: 10000
     read-delay-seconds: 10
     expected-node-count: 3000
     cluster-db-pool-size: 60

--- a/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerIntegrationSpec.groovy
+++ b/pipe-http-server/src/integration/groovy/com/tesco/aqueduct/pipe/http/PipeReadControllerIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class PipeReadControllerIntegrationSpec extends Specification {
     @Inject
     EmbeddedServer server
 
-    static int RETRY_AFTER_SECONDS = 600
+    static int RETRY_AFTER_MS = 600000
     static String type = "type1"
 
     void setup() {
@@ -61,12 +61,13 @@ class PipeReadControllerIntegrationSpec extends Specification {
             .then()
             .statusCode(statusCode)
             .content(equalTo(responseBody))
-            .header(HttpHeaders.RETRY_AFTER, "" + RETRY_AFTER_SECONDS)
+            .header(HttpHeaders.RETRY_AFTER, "" + RETRY_AFTER_MS / 1000)
+            .header(HttpHeaders.RETRY_AFTER_MS, "" + RETRY_AFTER_MS)
 
         where:
-        requestPath                         | statusCode | retryAfter          | responseBody
-        "/pipe/0?location='someLocation'"   | 200        | RETRY_AFTER_SECONDS | "[]"
-        "/pipe/1?location='someLocation'"   | 200        | RETRY_AFTER_SECONDS | "[]"
+        requestPath                       | statusCode | retryAfter     | responseBody
+        "/pipe/0?location='someLocation'" | 200        | RETRY_AFTER_MS | "[]"
+        "/pipe/1?location='someLocation'" | 200        | RETRY_AFTER_MS | "[]"
     }
 
     @Unroll

--- a/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
+++ b/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
@@ -71,19 +71,19 @@ public class PipeReadController {
 
         final MessageResults messageResults = reader.read(types, offset, locationResolver.resolve(location));
         final List<Message> list = messageResults.getMessages();
-        final long retryTime = messageResults.getRetryAfterMs();
+        final long retryAfterMs = messageResults.getRetryAfterMs();
 
-        LOG.debug("pipe read controller", String.format("set retry time to %d", retryTime));
+        LOG.debug("pipe read controller", String.format("set retry time to %d", retryAfterMs));
         byte[] responseBytes = JsonHelper.toJson(list).getBytes();
 
         ContentEncoder.EncodedResponse encodedResponse = contentEncoder.encodeResponse(request, responseBytes);
 
         Map<CharSequence, CharSequence> responseHeaders = new HashMap<>(encodedResponse.getHeaders());
 
-        final long retryAfterSeconds = (long) Math.ceil(retryTime / (double) 1000);
+        final long retryAfterSeconds = (long) Math.ceil(retryAfterMs / (double) 1000);
 
         responseHeaders.put(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
-        responseHeaders.put(HttpHeaders.RETRY_AFTER_MS, String.valueOf(retryTime));
+        responseHeaders.put(HttpHeaders.RETRY_AFTER_MS, String.valueOf(retryAfterMs));
         responseHeaders.put(HttpHeaders.PIPE_STATE,
                 pipeStateProvider.getState(types, reader).isUpToDate() ? UP_TO_DATE.toString() : OUT_OF_DATE.toString());
 

--- a/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
+++ b/pipe-http-server/src/main/java/com/tesco/aqueduct/pipe/http/PipeReadController.java
@@ -4,7 +4,6 @@ import com.tesco.aqueduct.pipe.api.*;
 import com.tesco.aqueduct.pipe.codec.ContentEncoder;
 import com.tesco.aqueduct.pipe.logger.PipeLogger;
 import com.tesco.aqueduct.pipe.metrics.Measure;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.convert.format.ReadableBytes;
 import io.micronaut.core.util.StringUtils;
@@ -28,7 +27,6 @@ import java.util.stream.Stream;
 
 import static com.tesco.aqueduct.pipe.api.PipeState.OUT_OF_DATE;
 import static com.tesco.aqueduct.pipe.api.PipeState.UP_TO_DATE;
-import static io.micronaut.http.HttpHeaders.ACCEPT_ENCODING;
 
 @Secured("PIPE_READ")
 @Measure
@@ -73,7 +71,7 @@ public class PipeReadController {
 
         final MessageResults messageResults = reader.read(types, offset, locationResolver.resolve(location));
         final List<Message> list = messageResults.getMessages();
-        final long retryTime = messageResults.getRetryAfterSeconds();
+        final long retryTime = messageResults.getRetryAfterMs();
 
         LOG.debug("pipe read controller", String.format("set retry time to %d", retryTime));
         byte[] responseBytes = JsonHelper.toJson(list).getBytes();
@@ -81,7 +79,11 @@ public class PipeReadController {
         ContentEncoder.EncodedResponse encodedResponse = contentEncoder.encodeResponse(request, responseBytes);
 
         Map<CharSequence, CharSequence> responseHeaders = new HashMap<>(encodedResponse.getHeaders());
-        responseHeaders.put(HttpHeaders.RETRY_AFTER, String.valueOf(retryTime));
+
+        final long retryAfterSeconds = (long) Math.ceil(retryTime / (double) 1000);
+
+        responseHeaders.put(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
+        responseHeaders.put(HttpHeaders.RETRY_AFTER_MS, String.valueOf(retryTime));
         responseHeaders.put(HttpHeaders.PIPE_STATE,
                 pipeStateProvider.getState(types, reader).isUpToDate() ? UP_TO_DATE.toString() : OUT_OF_DATE.toString());
 

--- a/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
+++ b/pipe-storage-postgresql/src/integration/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageIntegrationSpec.groovy
@@ -189,7 +189,7 @@ class PostgresqlStorageIntegrationSpec extends StorageSpec {
         MessageResults result = storage.read([], 4, ["clusterId"])
 
         then:
-        result.retryAfterSeconds > 0
+        result.retryAfterMs > 0
         result.messages.isEmpty()
     }
 
@@ -200,7 +200,7 @@ class PostgresqlStorageIntegrationSpec extends StorageSpec {
         MessageResults result = storage.read([], 0,["clusterId"])
 
         then:
-        result.retryAfterSeconds > 0
+        result.retryAfterMs > 0
         result.messages.isEmpty()
     }
 

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -133,11 +133,10 @@ public class PostgresqlStorage implements CentralStorage {
     }
   
     private void logCalculatedRetryAfterInMs(long queryTimeMs) {
-        final double dbThreshold = this.clusterDBPoolSize / queryTimeMs;
+        final double dbThreshold = this.clusterDBPoolSize / (double) queryTimeMs;
         final double retryAfterMs = this.nodeCount / dbThreshold;
         final long calculatedRetryAfter = (long) Math.ceil(retryAfterMs);
         LOG.info("PostgresSqlStorage:calculateRetryAfter:RetryAfterMs", String.valueOf(Math.min(calculatedRetryAfter, retryAfter * 1000)));
-
     }
 
     @Override

--- a/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
+++ b/pipe-storage-postgresql/src/main/java/com/tesco/aqueduct/pipe/storage/PostgresqlStorage.java
@@ -115,12 +115,10 @@ public class PostgresqlStorage implements CentralStorage {
             return 1;
         }
 
-        logCalculatedRetryAfterInMs(queryTimeMs);
-
         // retry after = readers / (connections / query time)
-        final double dbThreshold = this.clusterDBPoolSize * 1000 / queryTimeMs;
-        final double retryAfterSecs = this.nodeCount / dbThreshold;
-        final long calculatedRetryAfter = (long) Math.ceil(retryAfterSecs);
+        final double dbThreshold = this.clusterDBPoolSize / (double) queryTimeMs;
+        final double retryAfterMs = this.nodeCount / dbThreshold;
+        final long calculatedRetryAfter = (long) Math.ceil(retryAfterMs);
 
         LOG.info("PostgresSqlStorage:calculateRetryAfter:messagesCount", String.valueOf(messagesCount));
         LOG.info("PostgresSqlStorage:calculateRetryAfter:calculatedRetryAfter", String.valueOf(calculatedRetryAfter));
@@ -130,13 +128,6 @@ public class PostgresqlStorage implements CentralStorage {
 
     private long retryAfterWithRandomJitter() {
         return retryAfter + (long) (retryAfter * Math.random());
-    }
-  
-    private void logCalculatedRetryAfterInMs(long queryTimeMs) {
-        final double dbThreshold = this.clusterDBPoolSize / (double) queryTimeMs;
-        final double retryAfterMs = this.nodeCount / dbThreshold;
-        final long calculatedRetryAfter = (long) Math.ceil(retryAfterMs);
-        LOG.info("PostgresSqlStorage:calculateRetryAfter:RetryAfterMs", String.valueOf(Math.min(calculatedRetryAfter, retryAfter * 1000)));
     }
 
     @Override

--- a/pipe-storage-postgresql/src/test/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageSpec.groovy
+++ b/pipe-storage-postgresql/src/test/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageSpec.groovy
@@ -9,7 +9,7 @@ import javax.sql.DataSource
 class PostgresqlStorageSpec extends Specification {
 
     @Shared
-    def retryAfter = 30
+    def retryAfter = 30000
 
     @Unroll
     def "retry after is #result when queryTime is #timeOfQueryMs and message result size is #noOfMessages"() {
@@ -25,12 +25,12 @@ class PostgresqlStorageSpec extends Specification {
 
         where:
         timeOfQueryMs | noOfMessages | result
-        100           | 10000        | 5
-        200           | 10000        | 10
-        10            | 10000        | 1
-        50            | 10000        | 3
+        100           | 10000        | 5000
+        200           | 10000        | 10000
+        10            | 10000        | 500
+        50            | 10000        | 2500
         0             | 10000        | 1
-        1             | 10000        | 1
+        1             | 10000        | 50
     }
 
     @Unroll

--- a/pipe-storage-postgresql/src/test/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageSpec.groovy
+++ b/pipe-storage-postgresql/src/test/groovy/com/tesco/aqueduct/pipe/storage/PostgresqlStorageSpec.groovy
@@ -21,23 +21,35 @@ class PostgresqlStorageSpec extends Specification {
         def storage = new PostgresqlStorage(Mock(DataSource), 20, retryAfter, 2, 0, readersNodeCount, clusterDBPoolSize, 4)
 
         expect:
-        if (shouldBeGreaterThan) {
-            storage.calculateRetryAfter(timeOfQueryMs, noOfMessages) > result
-        } else {
-            storage.calculateRetryAfter(timeOfQueryMs, noOfMessages) == result
-        }
+        storage.calculateRetryAfter(timeOfQueryMs, noOfMessages) == result
 
         where:
-        timeOfQueryMs | noOfMessages | result     | shouldBeGreaterThan
-        100           | 0            | retryAfter | true
-        1234          | 0            | retryAfter | true
-        100           | 10000        | 5          | false
-        200           | 10000        | 10         | false
-        10            | 10000        | 1          | false
-        50            | 10000        | 3          | false
-        0             | 10000        | 1          | false
-        1             | 10000        | 1          | false
-        700           | 10000        | retryAfter | true
-        1000          | 10000        | retryAfter | true
+        timeOfQueryMs | noOfMessages | result
+        100           | 10000        | 5
+        200           | 10000        | 10
+        10            | 10000        | 1
+        50            | 10000        | 3
+        0             | 10000        | 1
+        1             | 10000        | 1
+    }
+
+    @Unroll
+    def "retry after is retryAfter*1000 when queryTime is #timeOfQueryMs and message result size is #noOfMessages"() {
+        given:
+        def readersNodeCount = 3000
+        def clusterDBPoolSize = 60
+
+        and:
+        def storage = new PostgresqlStorage(Mock(DataSource), 20, retryAfter, 2, 0, readersNodeCount, clusterDBPoolSize, 4)
+
+        expect:
+        storage.calculateRetryAfter(timeOfQueryMs, noOfMessages) >= result
+
+        where:
+        timeOfQueryMs | noOfMessages | result
+        100           | 0            | retryAfter
+        1234          | 0            | retryAfter
+        700           | 10000        | retryAfter
+        1000          | 10000        | retryAfter
     }
 }

--- a/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
+++ b/pipe-storage-sqlite/src/integration/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageIntegrationSpec.groovy
@@ -637,7 +637,7 @@ class SQLiteStorageIntegrationSpec extends Specification {
         MessageResults messageResults = sqliteStorage.read(null, 1, ["locationUuid"])
 
         then: 'the retry after is 0'
-        messageResults.retryAfterSeconds == 0
+        messageResults.retryAfterMs == 0
     }
 
     def 'throws an exception if there is a problem with the database connection on startup'() {

--- a/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
+++ b/pipe-storage-sqlite/src/main/java/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorage.java
@@ -21,15 +21,15 @@ public class SQLiteStorage implements DistributedStorage {
 
     private final DataSource dataSource;
     private final int limit;
-    private final int retryAfterSeconds;
+    private final int retryAfterMs;
     private final long maxBatchSize;
 
     private static final PipeLogger LOG = new PipeLogger(LoggerFactory.getLogger(SQLiteStorage.class));
 
-    public SQLiteStorage(final DataSource dataSource, final int limit, final int retryAfterSeconds, final long maxBatchSize) {
+    public SQLiteStorage(final DataSource dataSource, final int limit, final int retryAfterMs, final long maxBatchSize) {
         this.dataSource = dataSource;
         this.limit = limit;
-        this.retryAfterSeconds = retryAfterSeconds;
+        this.retryAfterMs = retryAfterMs;
         this.maxBatchSize = maxBatchSize + (((long)Message.MAX_OVERHEAD_SIZE) * limit);
 
         createEventTableIfNotExists();
@@ -108,7 +108,7 @@ public class SQLiteStorage implements DistributedStorage {
     }
 
     public int calculateRetryAfter(final int messageCount) {
-        return messageCount > 0 ? 0 : retryAfterSeconds;
+        return messageCount > 0 ? 0 : retryAfterMs;
     }
 
     private Message mapRetrievedMessageFromResultSet(final ResultSet resultSet) throws SQLException {


### PR DESCRIPTION
Maintain use of retryAfter header to allow for backwards compatibility. Will be removed in a later PR when all nodes have latest provider version