### PR TITLE
LC/AY fix requestedToFollow nodes in registration logs

### DIFF
--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
@@ -3,9 +3,18 @@ package com.tesco.aqueduct.registry.model;
 import java.util.List;
 
 public interface NodeRegistry {
-
+    /**
+     * @param node Node to register as new or update current state
+     * @return Node registered
+     */
     Node register(Node node);
 
+    /**
+     * @param offset Latest offset of root
+     * @param status Status of root
+     * @param groups List of groups to return, all if empty or null
+     * @return Summary of all currently known nodes
+     */
     StateSummary getSummary(long offset, Status status, List<String> groups);
 
     boolean deleteNode(String group, String host);

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
@@ -1,6 +1,5 @@
 package com.tesco.aqueduct.registry.model;
 
-import java.net.URL;
 import java.util.List;
 
 public interface NodeRegistry {
@@ -8,7 +7,7 @@ public interface NodeRegistry {
      * @param node Node to register as new or update current state
      * @return List of URL this node should currently follow
      */
-    List<URL> register(Node node);
+    Node register(Node node);
 
     /**
      * @param offset Latest offset of root

--- a/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
+++ b/registry-core/src/main/java/com/tesco/aqueduct/registry/model/NodeRegistry.java
@@ -3,18 +3,9 @@ package com.tesco.aqueduct.registry.model;
 import java.util.List;
 
 public interface NodeRegistry {
-    /**
-     * @param node Node to register as new or update current state
-     * @return List of URL this node should currently follow
-     */
+
     Node register(Node node);
 
-    /**
-     * @param offset Latest offset of root
-     * @param status Status of root
-     * @param groups List of groups to return, all if empty or null
-     * @return Summary of all currently known nodes
-     */
     StateSummary getSummary(long offset, Status status, List<String> groups);
 
     boolean deleteNode(String group, String host);

--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistryIntegrationSpec.groovy
@@ -199,9 +199,9 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         def followC = registerNode("groupC", "http://a")
 
         then: "All first nodes in the group get a cloud URL"
-        followA == [cloudURL]
-        followB == [cloudURL]
-        followC == [cloudURL]
+        followA.requestedToFollow == [cloudURL]
+        followB.requestedToFollow == [cloudURL]
+        followC.requestedToFollow == [cloudURL]
     }
 
     def "the second node in the group should be told to calls the first node"() {
@@ -209,10 +209,10 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         registerNode("x", "http://first")
 
         when: "Second node registers"
-        def follow = registerNode("x", "http://second")
+        def registeredNode = registerNode("x", "http://second")
 
         then: "It is told to call the first one"
-        follow == [new URL("http://first"), cloudURL]
+        registeredNode.requestedToFollow == [new URL("http://first"), cloudURL]
     }
 
     def "the third node in the group should be told to call the first node and the cloud"() {
@@ -223,12 +223,11 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         registerNode("x", "http://second")
 
         when: "Third node registers"
-        def follow = registerNode("x", "http://third")
+        def registeredNode = registerNode("x", "http://third")
 
         then: "It is told to call the first one"
-        follow == [new URL("http://first"), cloudURL]
+        registeredNode.requestedToFollow == [new URL("http://first"), cloudURL]
     }
-
 
     def "registering the same node again returns the unchanged hierarchy"() {
         given: "We have two nodes registered"
@@ -240,8 +239,8 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         def actualSecond = registerNode("x", "http://second")
 
         then: "It is told to call the cloud"
-        actualFirst == expectedFirst
-        actualSecond == expectedSecond
+        actualFirst.requestedToFollow == expectedFirst.requestedToFollow
+        actualSecond.requestedToFollow == expectedSecond.requestedToFollow
     }
 
     def "registering the same node again does not break the original hierarchy in storage"() {
@@ -280,7 +279,7 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         when: "Nodes register"
         nodes.times {
             String address = "http://1.1.1.${it+1}"
-            def firstFollower = registerNode("x", address).first()
+            def firstFollower = registerNode("x", address).requestedToFollow.first()
             nodeToChildren[firstFollower] << address
         }
         nodeToChildren.each {
@@ -321,14 +320,14 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
 
     def "explicit test of the binary tree logic"() {
         when: "nodes register"
-        def nodeList1 = registerNode("x", "http://1.1.1.1").toListString()
-        def nodeList2 = registerNode("x", "http://1.1.1.2").toListString()
-        def nodeList3 = registerNode("x", "http://1.1.1.3").toListString()
-        def nodeList4 = registerNode("x", "http://1.1.1.4").toListString()
-        def nodeList5 = registerNode("x", "http://1.1.1.5").toListString()
-        def nodeList6 = registerNode("x", "http://1.1.1.6").toListString()
-        def nodeList7 = registerNode("x", "http://1.1.1.7").toListString()
-        def nodeList8 = registerNode("x", "http://1.1.1.8").toListString()
+        def nodeList1 = registerNode("x", "http://1.1.1.1").requestedToFollow.toListString()
+        def nodeList2 = registerNode("x", "http://1.1.1.2").requestedToFollow.toListString()
+        def nodeList3 = registerNode("x", "http://1.1.1.3").requestedToFollow.toListString()
+        def nodeList4 = registerNode("x", "http://1.1.1.4").requestedToFollow.toListString()
+        def nodeList5 = registerNode("x", "http://1.1.1.5").requestedToFollow.toListString()
+        def nodeList6 = registerNode("x", "http://1.1.1.6").requestedToFollow.toListString()
+        def nodeList7 = registerNode("x", "http://1.1.1.7").requestedToFollow.toListString()
+        def nodeList8 = registerNode("x", "http://1.1.1.8").requestedToFollow.toListString()
 
         then: "The heirachy returned to each node forms a binary tree"
         nodeList1 == "[http://cloud.pipe:8080]"
@@ -518,8 +517,8 @@ class PostgreSQLNodeRegistryIntegrationSpec extends Specification {
         secondNode = registerNode("groupA", "http://a2", 123, FOLLOWING, [], ["v":"1.0"])
 
         then: "all three nodes follow cloud"
-        firstNode == [cloudURL]
-        secondNode == [new URL("http://a1"), cloudURL]
+        firstNode.requestedToFollow == [cloudURL]
+        secondNode.requestedToFollow == [new URL("http://a1"), cloudURL]
     }
 
     @Ignore

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/http/NodeRegistryControllerV2.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/http/NodeRegistryControllerV2.java
@@ -66,10 +66,10 @@ public class NodeRegistryControllerV2 {
             );
         }
         LOG.withNode(node).info("register node: ", "node registered");
-        final List<URL> requestedToFollow = registry.register(node);
+        final Node nodeRegistered = registry.register(node);
         final BootstrapType bootstrapType = nodeRequestStorage.requiresBootstrap(node.getHost());
         LOG.withNode(node).info("requested to follow", "node registration complete");
-        return new RegistryResponse(requestedToFollow, bootstrapType);
+        return new RegistryResponse(nodeRegistered.getRequestedToFollow(), bootstrapType);
     }
 
     @Secured(REGISTRY_DELETE)

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistry.java
@@ -42,7 +42,7 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
     }
 
     @Override
-    public List<URL> register(final Node nodeToRegister) {
+    public Node register(final Node nodeToRegister) {
         long start = System.currentTimeMillis();
 
         try (Connection connection = getConnection()) {
@@ -64,7 +64,7 @@ public class PostgreSQLNodeRegistry implements NodeRegistry {
             connection.commit();
             LOG.info("commit", Long.toString(System.currentTimeMillis() - start));
 
-            return node.getRequestedToFollow();
+            return node;
         } catch (SQLException | IOException exception) {
             LOG.error("Postgresql node registry", "register node", exception);
             throw new RuntimeException(exception);

--- a/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
+++ b/registry-http-server/src/test/groovy/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRegistrySpec.groovy
@@ -36,6 +36,6 @@ class PostgreSQLNodeRegistrySpec extends Specification {
 		def result = registry.register(testNode)
 
 		then: "the cloud url is returned"
-		result == [cloudUrl]
+		result.requestedToFollow == [cloudUrl]
 	}
 }


### PR DESCRIPTION
Currently the "node registration completed" log is logging the requestToFollow nodes as empty while they should be populated. This is the PR to fix it