### PR TITLE
LC/AS double IO thread pool

### DIFF
--- a/pipe-http-server-cloud/src/main/resources/application.yml
+++ b/pipe-http-server-cloud/src/main/resources/application.yml
@@ -22,7 +22,7 @@ micronaut:
   executors:
     io:
       type: fixed
-      nThreads: 14
+      nThreads: 28
   server:
     netty:
       worker:


### PR DESCRIPTION
This is to prevent slow HTTP requests to use all the IO threads available while other are queuing up waiting for a free thread