### PR TITLE
AS/WP/MW - Remove jaeger dependency

### DIFF
--- a/pipe-http-server-cloud/build.gradle
+++ b/pipe-http-server-cloud/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation project (":pipe-logger")
 
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
-    implementation 'io.jaegertracing:jaeger-core:1.3.1'
 
     addMicronautDependencies()
     implementation 'io.micronaut.cache:micronaut-cache-core'

--- a/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/http/Bindings.java
+++ b/pipe-http-server-cloud/src/main/java/com/tesco/aqueduct/pipe/http/Bindings.java
@@ -14,11 +14,9 @@ import com.tesco.aqueduct.registry.model.NodeRegistry;
 import com.tesco.aqueduct.registry.model.NodeRequestStorage;
 import com.tesco.aqueduct.registry.postgres.PostgreSQLNodeRegistry;
 import com.tesco.aqueduct.registry.postgres.PostgreSQLNodeRequestStorage;
-import io.jaegertracing.Configuration;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
-import io.opentracing.Tracer;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -32,7 +30,8 @@ import java.time.Duration;
 public class Bindings {
 
     // This provides Reader as it implements it
-    @Singleton @Named("local")
+    @Singleton
+    @Named("local")
     PostgresqlStorage bindPostgreSQL(
         @Property(name = "persistence.read.limit") final int limit,
         @Property(name = "persistence.read.retry-after") final int retryAfter,
@@ -90,8 +89,4 @@ public class Bindings {
         return new CloudLocationService(locationServiceClientProvider);
     }
 
-    @Singleton
-    public Tracer tracer() {
-        return new Configuration("Aqueduct Core").getTracer();
-    }
 }

--- a/telemetry/build.gradle
+++ b/telemetry/build.gradle
@@ -1,7 +1,3 @@
 addMicronautDependencies()
 
-dependencies {
-    implementation 'io.jaegertracing:jaeger-core:1.3.1'
-}
-
 addPublish()


### PR DESCRIPTION
### What is being changed

Remove the Jaeger dependency. 

### Why are we doing this?

Jaeger is an implementation of OpenTracing. It adds an `uber-trace-id` header to requests, when the request fails it duplicates this trace ID and tries to send the request again. Because of the circuit breaker this can end up duplicating the trace ID many times. This means when the eventual request is made to Identity it fails with a `HTTP 431 Request Header Fields Too Large` response status.

Removing the `uber-trace-id` header will mean the request will be able to recover once the circuit breaker is closed. 

### Implementation details

Removed Jaeger dependency.