### PR TITLE
Replaced HttpClientConfiguration with HttpClient in ServiceList

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ plugins {
 
 apply plugin: 'org.owasp.dependencycheck'
 apply plugin: 'pl.allegro.tech.build.axion-release'
+apply plugin:'java'
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 
 dependencyCheck {
 

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/AuthenticatePipeReadFilterIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/AuthenticatePipeReadFilterIntegrationSpec.groovy
@@ -7,6 +7,7 @@ import com.tesco.aqueduct.registry.client.PipeServiceInstance
 import com.tesco.aqueduct.registry.client.ServiceList
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import io.reactivex.Single
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -72,10 +73,10 @@ class AuthenticatePipeReadFilterIntegrationSpec extends Specification {
             .build()
             .registerSingleton(tokenProvider)
             .registerSingleton(new ServiceList(
-                new DefaultHttpClientConfiguration(),
-                new PipeServiceInstance(config, new URL(server.getHttpUrl())),
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL(server.getHttpUrl())),
                 File.createTempFile("provider", "properties")
-        ))
+            ))
             .start()
 
         client = context.getBean(InternalBrotliHttpPipeClient)
@@ -132,9 +133,9 @@ class AuthenticatePipeReadFilterIntegrationSpec extends Specification {
                 .build()
                 .registerSingleton(TokenProvider, Mock(TokenProvider))
                 .registerSingleton(new ServiceList(
-                        new DefaultHttpClientConfiguration(),
-                        new PipeServiceInstance(config, new URL(server.getHttpUrl())),
-                        File.createTempFile("provider", "properties")
+                    new DefaultHttpClient(),
+                    new PipeServiceInstance(new DefaultHttpClient(), new URL(server.getHttpUrl())),
+                    File.createTempFile("provider", "properties")
                 ))
                 .start()
 

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalBrotliHttpPipeClientIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalBrotliHttpPipeClientIntegrationSpec.groovy
@@ -7,8 +7,8 @@ import com.tesco.aqueduct.registry.client.PipeServiceInstance
 import com.tesco.aqueduct.registry.client.SelfRegistrationTask
 import com.tesco.aqueduct.registry.client.ServiceList
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.netty.DefaultHttpClient
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -42,8 +42,8 @@ class InternalBrotliHttpPipeClientIntegrationSpec extends Specification {
             .registerSingleton(SelfRegistrationTask, Mock(SelfRegistrationTask))
             .registerSingleton(Mock(TokenProvider))
             .registerSingleton(new ServiceList(
-                new DefaultHttpClientConfiguration(),
-                new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(wireMockRule.baseUrl())),
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL(wireMockRule.baseUrl())),
                 File.createTempFile("provider", "properties")
             ))
             .start()

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalGzipHttpPipeClientIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/InternalGzipHttpPipeClientIntegrationSpec.groovy
@@ -7,8 +7,8 @@ import com.tesco.aqueduct.registry.client.PipeServiceInstance
 import com.tesco.aqueduct.registry.client.SelfRegistrationTask
 import com.tesco.aqueduct.registry.client.ServiceList
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.netty.DefaultHttpClient
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -42,8 +42,8 @@ class InternalGzipHttpPipeClientIntegrationSpec extends Specification {
             .registerSingleton(SelfRegistrationTask, Mock(SelfRegistrationTask))
             .registerSingleton(Mock(TokenProvider))
             .registerSingleton(new ServiceList(
-                new DefaultHttpClientConfiguration(),
-                new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(wireMockRule.baseUrl())),
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL(wireMockRule.baseUrl())),
                 File.createTempFile("provider", "properties")
             ))
             .start()

--- a/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
+++ b/pipe-http-client/src/integration/groovy/com/tesco/aqueduct/pipe/http/client/PipeLoadBalancerIntegrationSpec.groovy
@@ -10,8 +10,8 @@ import com.tesco.aqueduct.registry.client.PipeServiceInstance
 import com.tesco.aqueduct.registry.client.SelfRegistrationTask
 import com.tesco.aqueduct.registry.client.ServiceList
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.netty.DefaultHttpClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -61,8 +61,8 @@ class PipeLoadBalancerIntegrationSpec extends Specification {
             .registerSingleton(Mock(TokenProvider))
             .registerSingleton(BrotliCodec, brotliCodec)
             .registerSingleton(new ServiceList(
-                new DefaultHttpClientConfiguration(),
-                new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL("http://does.not.exist")),
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL("http://does.not.exist")),
                 File.createTempFile("provider", "properties")
             ))
             .start()

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceIntegrationSpec.groovy
@@ -2,7 +2,7 @@ package com.tesco.aqueduct.registry.client
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import com.github.tomakehurst.wiremock.stubbing.Scenario
-import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -16,7 +16,7 @@ class PipeServiceInstanceIntegrationSpec extends Specification {
 
     def "sets flag isUp to true when a valid http response is returned"() {
         given:
-        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(wireMockRule.baseUrl()))
+        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL(wireMockRule.baseUrl()))
 
         and:
         stubFor(
@@ -37,7 +37,7 @@ class PipeServiceInstanceIntegrationSpec extends Specification {
     @Unroll
     def "sets flag isUp to false when the service is down with status as #status"() {
         given:
-        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(wireMockRule.baseUrl()))
+        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL(wireMockRule.baseUrl()))
 
         and:
         stubFor(
@@ -66,7 +66,7 @@ class PipeServiceInstanceIntegrationSpec extends Specification {
     @Unroll
     def "checkState retries twice if request fails on first attempt"() {
         given:
-        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(wireMockRule.baseUrl()))
+        def pipeServiceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL(wireMockRule.baseUrl()))
 
         and:
         stubFor(get(urlEqualTo("/pipe/_status")).inScenario("healthcheck")

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
@@ -7,7 +7,7 @@ import com.tesco.aqueduct.registry.model.Bootstrapable
 import com.tesco.aqueduct.registry.model.Node
 import com.tesco.aqueduct.registry.model.Resetable
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.reactivex.Single
 import spock.lang.AutoCleanup
@@ -62,8 +62,8 @@ class RegistryClientIntegrationSpec extends Specification {
             .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("controller"))
             .registerSingleton(Resetable.class, Mock(Resetable), Qualifiers.byName("corruptionManager"))
             .registerSingleton(new ServiceList(
-                new DefaultHttpClientConfiguration(),
-                new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL(server.getHttpUrl())),
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL(server.getHttpUrl())),
                 File.createTempFile("provider", "properties")
             ))
             .start()

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/ServiceListIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/ServiceListIntegrationSpec.groovy
@@ -2,6 +2,7 @@ package com.tesco.aqueduct.registry.client
 
 import com.stehno.ersatz.ErsatzServer
 import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import io.micronaut.http.uri.UriBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -19,7 +20,7 @@ class ServiceListIntegrationSpec extends Specification {
     def setup() {
         def config = new DefaultHttpClientConfiguration()
         File existingPropertiesFile = folder.newFile()
-        serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
     }
 
     def "check state respects the base path of all the servers in the list when performing the status check"() {

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
@@ -18,7 +18,7 @@ public class PipeServiceInstance implements ServiceInstance {
 
     private final HttpClient httpClient;
     private final URL url;
-    private boolean up = false;
+    private boolean up = true;
     private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(PipeServiceInstance.class));
 
     @Inject

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
@@ -3,8 +3,6 @@ package com.tesco.aqueduct.registry.client;
 import com.tesco.aqueduct.registry.utils.RegistryLogger;
 import io.micronaut.discovery.ServiceInstance;
 import io.micronaut.http.client.HttpClient;
-import io.micronaut.http.client.HttpClientConfiguration;
-import io.micronaut.http.client.netty.DefaultHttpClient;
 import io.micronaut.http.uri.UriBuilder;
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -86,22 +84,6 @@ public class PipeServiceInstance implements ServiceInstance {
 
     private void logError(Throwable throwable) {
         LOG.error("healthcheck.failed", url + " failed with error " + throwable.getMessage(), "");
-    }
-
-    private Completable updateState(final HttpClient client) {
-        return Single.fromPublisher(client.retrieve(withStatusUrlFromBaseUri()))
-            // if got response, then it's a true
-            .map(response -> true)
-            // log result
-            .doOnSuccess(b -> LOG.debug("healthcheck.success", url.toString()))
-            .doOnError(this::logError)
-            .retry(2)
-            // change exception to "false"
-            .onErrorResumeNext(Single.just(false))
-            // set the status of the instance
-            .doOnSuccess(this::isUp)
-            // return as completable, close client and ignore any errors
-            .ignoreElement(); // returns completable
     }
 
     private String withStatusUrlFromBaseUri() {

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
@@ -18,14 +18,14 @@ import java.nio.file.Paths;
 
 public class PipeServiceInstance implements ServiceInstance {
 
-    private final HttpClientConfiguration configuration;
+    private final HttpClient httpClient;
     private final URL url;
     private boolean up = true;
     private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(PipeServiceInstance.class));
 
     @Inject
-    public PipeServiceInstance(final HttpClientConfiguration configuration, final URL url) {
-        this.configuration = configuration;
+    public PipeServiceInstance(final HttpClient httpClient, final URL url) {
+        this.httpClient = httpClient;
         this.url = url;
     }
 
@@ -68,12 +68,7 @@ public class PipeServiceInstance implements ServiceInstance {
     }
 
     Completable updateState() {
-        return Completable
-            .using(
-                () -> new DefaultHttpClient(url.toURI(), configuration),
-                this::updateState,
-                DefaultHttpClient::close
-            )
+        return Completable.fromCallable(this::updateState)
             .doOnError(throwable -> {
                 this.isUp(false);
                 logError(throwable);

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
@@ -26,9 +26,9 @@ public class ServiceList {
     private ZonedDateTime lastUpdatedTime;
 
     public ServiceList(
-            HttpClient httpClient,
-            final PipeServiceInstance pipeServiceInstance,
-            File file
+        HttpClient httpClient,
+        final PipeServiceInstance pipeServiceInstance,
+        File file
     ) throws IOException {
         this.httpClient = httpClient;
         this.cloudInstance = pipeServiceInstance;

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
@@ -1,7 +1,7 @@
 package com.tesco.aqueduct.registry.client;
 
 import com.tesco.aqueduct.registry.utils.RegistryLogger;
-import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.client.HttpClient;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
@@ -19,18 +19,18 @@ import static io.reactivex.Flowable.fromIterable;
 
 public class ServiceList {
     private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(ServiceList.class));
-    private final HttpClientConfiguration configuration;
+    private final HttpClient httpClient;
     private List<PipeServiceInstance> services;
     private final PipeServiceInstance cloudInstance;
     private final File file;
     private ZonedDateTime lastUpdatedTime;
 
     public ServiceList(
-        final HttpClientConfiguration configuration,
-        final PipeServiceInstance pipeServiceInstance,
-        File file
+            HttpClient httpClient,
+            final PipeServiceInstance pipeServiceInstance,
+            File file
     ) throws IOException {
-        this.configuration = configuration;
+        this.httpClient = httpClient;
         this.cloudInstance = pipeServiceInstance;
         services = new ArrayList<>();
         lastUpdatedTime = null;
@@ -128,7 +128,7 @@ public class ServiceList {
 
     private PipeServiceInstance getServiceInstance(final URL url) {
         return findPreviousInstance(url)
-            .orElseGet(() -> new PipeServiceInstance(configuration, url));
+            .orElseGet(() -> new PipeServiceInstance(httpClient, url));
     }
 
     private Optional<PipeServiceInstance> findPreviousInstance(final URL url) {

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeLoadBalancerSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeLoadBalancerSpec.groovy
@@ -2,6 +2,7 @@ package com.tesco.aqueduct.registry.client
 
 
 import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -23,7 +24,7 @@ class PipeLoadBalancerSpec extends Specification {
 
     def setup() {
         def config = new DefaultHttpClientConfiguration()
-        serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), folder.newFile())
+        serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), folder.newFile())
         loadBalancer = new PipeLoadBalancer(serviceList)
     }
 

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceSpec.groovy
@@ -1,7 +1,6 @@
 package com.tesco.aqueduct.registry.client
 
-import io.micronaut.http.client.DefaultHttpClientConfiguration
-import io.micronaut.http.client.HttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -13,7 +12,7 @@ class PipeServiceInstanceSpec extends Specification {
         given: "A url with a base path"
         def url = URL(baseUrl)
         def uri = new URI("/pipe/0")
-        def serviceInstance = new PipeServiceInstance(Mock(HttpClientConfiguration), url)
+        def serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), url)
 
         when: "resolving a relative uri"
         def response = serviceInstance.resolve(uri)
@@ -31,7 +30,7 @@ class PipeServiceInstanceSpec extends Specification {
 
     def "RxClient errors are not rethrown"() {
         given: "client throwing errors"
-        def serviceInstance = new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL("http://not.a.url"))
+        def serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL("http://not.a.url"))
 
         when: "we check the state"
         serviceInstance.updateState().blockingAwait()
@@ -45,7 +44,7 @@ class PipeServiceInstanceSpec extends Specification {
 
     def "error handled when uri is not valid"() {
         given: "pipe service instance with invalid uri"
-        def serviceInstance = new PipeServiceInstance(new DefaultHttpClientConfiguration(), new URL("http://"))
+        def serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL("http://"))
 
         when: "we check the state"
         serviceInstance.updateState().blockingAwait()

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/ServiceListSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/ServiceListSpec.groovy
@@ -1,6 +1,7 @@
 package com.tesco.aqueduct.registry.client
 
 import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.netty.DefaultHttpClient
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -11,7 +12,7 @@ class ServiceListSpec extends Specification {
     private final static URL URL_1 = URL("http://a1")
     private final static URL URL_2 = URL("http://a2")
     private final static URL URL_3 = URL("http://a3")
-    private PipeServiceInstance serviceInstance = new PipeServiceInstance(config, URL_1)
+    private PipeServiceInstance serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), URL_1)
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder()
@@ -26,7 +27,7 @@ class ServiceListSpec extends Specification {
 
     def "services that are updated are returned in the getServices"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
         def list = [URL_1, URL_2, URL_3]
 
         when: "service list is updated"
@@ -38,7 +39,7 @@ class ServiceListSpec extends Specification {
 
     def "when services are updated, obsolete services are removed"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
 
         and: "the service list has been updated before"
         serviceList.update([URL_1, URL_2])
@@ -53,7 +54,7 @@ class ServiceListSpec extends Specification {
 
     def "when services are updated, previous services keep their status"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
 
         and: "the service list has been updated before"
         serviceList.update([URL_1, URL_2])
@@ -75,7 +76,7 @@ class ServiceListSpec extends Specification {
 
     def "service list always contains at least the cloud url"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
 
         when: "the service list has not been updated yet"
 
@@ -97,7 +98,7 @@ class ServiceListSpec extends Specification {
 
     def "service list does not contain cloud url if updated with a list without it"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
 
         when: "the service list is updated with a list without the cloud url"
         serviceList.update([URL_2, URL_3])
@@ -119,7 +120,7 @@ class ServiceListSpec extends Specification {
 
         when: "a new service list is created"
         def config = new DefaultHttpClientConfiguration()
-        ServiceList serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         then: "the services returned are the persisted list"
         serviceList.stream().map({m -> m.getUrl()}).collect() == [URL_2, URL_3]
@@ -131,7 +132,7 @@ class ServiceListSpec extends Specification {
 
         when: "a new service list is created"
         def config = new DefaultHttpClientConfiguration()
-        ServiceList serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         then: "the services returned is just the cloud URL"
         serviceList.stream().map({m -> m.getUrl()}).collect() == [URL_1]
@@ -144,7 +145,7 @@ class ServiceListSpec extends Specification {
 
         when: "a new service list is created"
         def config = new DefaultHttpClientConfiguration()
-        ServiceList serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         then: "the services returned is just the cloud URL"
         serviceList.stream().map({m -> m.getUrl()}).collect() == [URL_1]
@@ -154,7 +155,7 @@ class ServiceListSpec extends Specification {
         given: "a service list with a file"
         def existingPropertiesFile = folder.newFile()
         def config = new DefaultHttpClientConfiguration()
-        ServiceList serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         when: "service list is updated"
         serviceList.update([URL_2, URL_3])
@@ -167,13 +168,13 @@ class ServiceListSpec extends Specification {
         given: "service list"
         def existingPropertiesFile = folder.newFile()
         def config = new DefaultHttpClientConfiguration()
-        ServiceList serviceList = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         when: "service list is updated and persists"
         serviceList.update([URL_2, URL_3])
 
         and: "a second service list is created"
-        ServiceList serviceList2 = new ServiceList(config, new PipeServiceInstance(config, URL_1), existingPropertiesFile)
+        ServiceList serviceList2 = new ServiceList(new DefaultHttpClient(), new PipeServiceInstance(new DefaultHttpClient(), URL_1), existingPropertiesFile)
 
         then: "the second service list can read the persisted values"
         serviceList2.stream().map({m -> m.getUrl()}).collect() == [URL_2, URL_3]
@@ -181,7 +182,7 @@ class ServiceListSpec extends Specification {
 
     def "service list contains last updated time"() {
         given: "a service list"
-        ServiceList serviceList = new ServiceList(config, serviceInstance, existingPropertiesFile)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile)
         def list = [URL_1, URL_2, URL_3]
 
         when: "service list is updated"


### PR DESCRIPTION
## What
The constructor argument of ServiceList, which used to take HttpClientConfiguration, has been updated to take HttpClient itself.

## Why
There are two reasons for this change: -
1. The provider was creating a fresh instance for each service (i.e. parents in the path to the cloud). Making a change here will reuse the same instance of HttpClient across all services except the cloud service.
2. The filters were not getting injected (to pass custom headers with the requests) as the HttpClient was being created with just URI and configuration by the PipeServiceInstance. Hence, the filters were empty and Micronaut was not even involved.

## How
The ServiceList constructor signature was refactored to use HttpClient. Then all the corresponding changes were made to ensure successful compilation and tests.

## Pairs
@ashish-sharma09 @ankurj77 