### PR TITLE
Auto bootstrap stale tills

### DIFF
--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/AuthenticateNodeRegistryFilterIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/AuthenticateNodeRegistryFilterIntegrationSpec.groovy
@@ -69,7 +69,7 @@ class AuthenticateNodeRegistryFilterIntegrationSpec extends Specification {
             .build()
 
         when: "the node is registered"
-        client.register(myNode)
+        client.registerAndConsumeBootstrapRequest(myNode)
 
         then: "the server receives the auth"
         server.verify()
@@ -117,7 +117,7 @@ class AuthenticateNodeRegistryFilterIntegrationSpec extends Specification {
             .build()
 
         def client = context.getBean(RegistryClient)
-        def response = client.register(myNode)
+        def response = client.registerAndConsumeBootstrapRequest(myNode)
 
         then: "a list of expected urls are returned"
         response.requestedToFollow == [new URL(host1), new URL(host2)]

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
@@ -3,115 +3,86 @@ package com.tesco.aqueduct.registry.client
 import com.stehno.ersatz.ErsatzServer
 import com.tesco.aqueduct.pipe.api.IdentityToken
 import com.tesco.aqueduct.pipe.api.TokenProvider
-import com.tesco.aqueduct.registry.model.Bootstrapable
+import com.tesco.aqueduct.registry.model.BootstrapType
 import com.tesco.aqueduct.registry.model.Node
-import com.tesco.aqueduct.registry.model.Resetable
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.netty.DefaultHttpClient
-import io.micronaut.inject.qualifiers.Qualifiers
 import io.reactivex.Single
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.ZonedDateTime
-import java.util.function.Supplier
 
 import static com.tesco.aqueduct.registry.model.Status.INITIALISING
 
 class RegistryClientIntegrationSpec extends Specification {
 
-    private static final URL MY_HOST = new URL("http://localhost")
-    String host1 = "http://host1"
-    String host2 = "http://host2"
+    String HOST_1 = "http://host1"
+    String HOST_2 = "http://host2"
 
-    def tokenProvider = Mock(TokenProvider) {
-        retrieveIdentityToken() >> Single.just(Mock(IdentityToken))
-    }
+    @Shared
+    @AutoCleanup
+    ErsatzServer server = new ErsatzServer()
+    ApplicationContext context
 
-    @Shared @AutoCleanup ErsatzServer server
+    RegistryClient client
 
-    SummarySupplier selfSummarySupplier = Mock()
-
-    Supplier<Map<String, Object>> providerMetricsSupplier = Mock()
     def setupSpec() {
-        server = new ErsatzServer()
         server.start()
     }
 
-    def 'test registry endpoint'() {
-        given: "A dummy server's application context"
+    def cleanupSpec() {
+        server.stop()
+    }
 
-        def context = ApplicationContext
+    void setup() {
+        context = ApplicationContext
             .builder()
             .properties(
                 "registry.http.client.url": server.getHttpUrl() + "/v2",
-                "registry.http.interval": "1m",
                 "registry.http.client.delay": "500ms",
                 "registry.http.client.attempts": "1",
                 "registry.http.client.reset": "1s",
-                "pipe.http.client.url": server.getHttpUrl(),
-                "pipe.http.client.healthcheck.interval": "1m"
             )
             .build()
             .registerSingleton(tokenProvider)
-            .registerSingleton(SummarySupplier.class, selfSummarySupplier, Qualifiers.byName("selfSummarySupplier"))
-            .registerSingleton(Supplier.class, providerMetricsSupplier, Qualifiers.byName("providerMetricsSupplier"))
-            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("provider"))
-            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("pipe"))
-            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("controller"))
-            .registerSingleton(Resetable.class, Mock(Resetable), Qualifiers.byName("corruptionManager"))
-            .registerSingleton(new ServiceList(
-                new DefaultHttpClient(),
-                new PipeServiceInstance(new DefaultHttpClient(), new URL(server.getHttpUrl())),
-                File.createTempFile("provider", "properties")
-            ))
             .start()
 
-        and: "a fake response from the server"
-        server.expectations {
-            POST("/v2/registry") {
-                header("Accept-Encoding", "gzip, deflate")
-                called(1)
+        client = context.getBean(RegistryClient)
+    }
 
-                responder {
-                    contentType("application/json")
-                    body("""{"requestedToFollow" : [ "$host1", "$host2" ], "bootstrapType" : "NONE"}""")
-                }
-            }
-            GET("/pipe/_status") {
-                called(1)
-                responder {
-                    contentType("application/json")
-                }
-            }
-        }
-
-        and: "A Micronaut-generated Client"
-        def client = context.getBean(RegistryClient)
-
-        and: "We have a node in the NodeRegistry"
-        def myNode = Node.builder()
+    def "should register with node"() {
+        given: "a node"
+        def node = Node.builder()
             .group("1234")
-            .localUrl(MY_HOST)
+            .localUrl(new URL("http://localhost"))
             .offset(0)
             .status(INITIALISING)
             .lastSeen(ZonedDateTime.now())
             .build()
 
-        selfSummarySupplier.getSelfNode() >> {
-            myNode
+        and: "a valid response from the server"
+        server.expectations {
+            POST("/v2/registry") {
+                header("Accept-Encoding", "gzip, deflate")
+
+                responder {
+                    contentType("application/json")
+                    body("""{"requestedToFollow" : [ "$HOST_1", "$HOST_2" ], "bootstrapType" : "NONE"}""")
+                }
+            }
         }
 
-        when: "We call register using the Micronaut client"
-        def response = client.registerAndConsumeBootstrapRequest(myNode)
+        when: "we call register with a node"
+        def response = client.registerAndConsumeBootstrapRequest(node)
 
-        then: "We expect the dummy server to return a list of URLs"
-        response.requestedToFollow.size() == 2
-        response.requestedToFollow == [new URL(host1), new URL(host2)]
+        then: "we receive the correct response"
+        response.requestedToFollow == [new URL(HOST_1), new URL(HOST_2)]
+        response.bootstrapType == BootstrapType.NONE
+    }
 
-        cleanup:
-        server.stop()
+    def tokenProvider = Mock(TokenProvider) {
+        retrieveIdentityToken() >> Single.just(Mock(IdentityToken))
     }
 }
 

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryClientIntegrationSpec.groovy
@@ -104,7 +104,7 @@ class RegistryClientIntegrationSpec extends Specification {
         }
 
         when: "We call register using the Micronaut client"
-        def response = client.register(myNode)
+        def response = client.registerAndConsumeBootstrapRequest(myNode)
 
         then: "We expect the dummy server to return a list of URLs"
         response.requestedToFollow.size() == 2

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryToServiceListIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryToServiceListIntegrationSpec.groovy
@@ -90,8 +90,8 @@ class RegistryToServiceListIntegrationSpec extends Specification {
         pipeLoadBalancerHealthCheckTask = context.getBean(PipeLoadBalancerHealthCheckTask)
     }
 
-    def "given a new service endpoint by registry, the till starts to follow that"() {
-        given: "registry server which returns the new service URL"
+    def "given a new service host by registry, the till starts to follow that"() {
+        given: "registry server which returns the new service host"
         def serviceURL = serviceServer.getHttpUrl()
         cloudServer.expectations {
             POST("/v2/registry") {
@@ -103,7 +103,7 @@ class RegistryToServiceListIntegrationSpec extends Specification {
                 }
             }
         }
-        and: "service server is healthy"
+        and: "service host is healthy"
         serviceServer.expectations {
             GET("/pipe/_status") {
                 called(1)
@@ -116,12 +116,12 @@ class RegistryToServiceListIntegrationSpec extends Specification {
             }
         }
 
-        when: "SelfRegistrationTask calls registry server"
+        when: "SelfRegistrationTask calls registry"
         selfRegistrationTask.register()
         and: "service health check is called"
         pipeLoadBalancerHealthCheckTask.checkState()
 
-        then: "the new service URL is called"
+        then: "the new service health check is called"
         serviceServer.verify()
     }
 }

--- a/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryToServiceListIntegrationSpec.groovy
+++ b/registry-client/src/integration/groovy/com/tesco/aqueduct/registry/client/RegistryToServiceListIntegrationSpec.groovy
@@ -1,0 +1,127 @@
+package com.tesco.aqueduct.registry.client
+
+import com.stehno.ersatz.ErsatzServer
+import com.tesco.aqueduct.pipe.api.IdentityToken
+import com.tesco.aqueduct.pipe.api.TokenProvider
+import com.tesco.aqueduct.registry.model.Bootstrapable
+import com.tesco.aqueduct.registry.model.Node
+import com.tesco.aqueduct.registry.model.Resetable
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.netty.DefaultHttpClient
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.reactivex.Single
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+
+import static com.tesco.aqueduct.registry.model.Status.INITIALISING
+
+class RegistryToServiceListIntegrationSpec extends Specification {
+    @Shared
+    @AutoCleanup
+    ErsatzServer cloudServer = new ErsatzServer()
+
+    @Shared
+    @AutoCleanup
+    ErsatzServer serviceServer = new ErsatzServer()
+
+    TokenProvider tokenProvider = Mock(TokenProvider) {
+        retrieveIdentityToken() >> Single.just(Mock(IdentityToken))
+    }
+
+    SummarySupplier summarySupplier = Mock(SummarySupplier) {
+        getSelfNode() >> Node.builder()
+            .group("1234")
+            .localUrl(new URL("http://localhost"))
+            .offset(0)
+            .status(INITIALISING)
+            .lastSeen(ZonedDateTime.now())
+            .build()
+    }
+
+    ApplicationContext context
+    SelfRegistrationTask selfRegistrationTask
+    PipeLoadBalancerHealthCheckTask pipeLoadBalancerHealthCheckTask
+
+    def setupSpec() {
+        cloudServer.start()
+        serviceServer.start()
+    }
+
+    void setup() {
+        cloudServer.expectations {
+            GET("/pipe/_status") {
+                responder {
+                    contentType('application/json')
+                    body("""[]""")
+                    code(200)
+                }
+            }
+        }
+
+        context = ApplicationContext
+            .builder()
+            .properties(
+                "registry.http.client.url": cloudServer.getHttpUrl() + "/v2",
+                "registry.http.client.delay": "500ms",
+                "registry.http.client.attempts": "1",
+                "registry.http.client.reset": "1s",
+                "registry.http.interval": "15m",
+                "pipe.http.client.healthcheck.interval": "15m",
+                "persistence.compact.deletions.threshold": "30d"
+            )
+            .build()
+            .registerSingleton(tokenProvider)
+            .registerSingleton(summarySupplier)
+            .registerSingleton(new ServiceList(
+                new DefaultHttpClient(),
+                new PipeServiceInstance(new DefaultHttpClient(), new URL(cloudServer.getHttpUrl())),
+                File.createTempFile("provider", "properties")
+            ))
+            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("provider"))
+            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("pipe"))
+            .registerSingleton(Bootstrapable.class, Mock(Bootstrapable), Qualifiers.byName("controller"))
+            .registerSingleton(Resetable.class, Mock(Resetable), Qualifiers.byName("corruptionManager"))
+            .start()
+
+        selfRegistrationTask = context.getBean(SelfRegistrationTask)
+        pipeLoadBalancerHealthCheckTask = context.getBean(PipeLoadBalancerHealthCheckTask)
+    }
+
+    def "given a new service endpoint by registry, the till starts to follow that"() {
+        given: "registry server which returns the new service URL"
+        def serviceURL = serviceServer.getHttpUrl()
+        cloudServer.expectations {
+            POST("/v2/registry") {
+                header("Accept-Encoding", "gzip, deflate")
+
+                responder {
+                    contentType("application/json")
+                    body("""{"requestedToFollow" : [ "$serviceURL" ], "bootstrapType" : "NONE"}""")
+                }
+            }
+        }
+        and: "service server is healthy"
+        serviceServer.expectations {
+            GET("/pipe/_status") {
+                called(1)
+
+                responder {
+                    contentType('application/json')
+                    body("""[]""")
+                    code(200)
+                }
+            }
+        }
+
+        when: "SelfRegistrationTask calls registry server"
+        selfRegistrationTask.register()
+        and: "service health check is called"
+        pipeLoadBalancerHealthCheckTask.checkState()
+
+        then: "the new service URL is called"
+        serviceServer.verify()
+    }
+}

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -24,14 +24,14 @@ public class BootstrapService {
                             @Named("pipe") final Bootstrapable pipe,
                             @Named("controller") final Bootstrapable controller,
                             @Named("corruptionManager") Resetable corruptionManager,
-                            @Property(name = "registry.http.interval") final Duration retryInterval,
+                            @Property(name = "registry.http.interval") final String retryInterval,
                             @Value("${pipe.bootstrap.delay:300000}") final int additionalDelay // 5 minutes extra to allow all nodes to reset
     ) {
         this.provider = provider;
         this.pipe = pipe;
         this.controller = controller;
         this.corruptionManager = corruptionManager;
-        this.bootstrapDelayMs = retryInterval.toMillis() + additionalDelay;
+        this.bootstrapDelayMs = Duration.parse("PT" + retryInterval).toMillis() + additionalDelay;
     }
 
     public void bootstrap(BootstrapType bootstrapType) throws Exception {

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -24,14 +24,14 @@ public class BootstrapService {
                             @Named("pipe") final Bootstrapable pipe,
                             @Named("controller") final Bootstrapable controller,
                             @Named("corruptionManager") Resetable corruptionManager,
-                            @Property(name = "registry.http.interval") String retryInterval,
+                            @Property(name = "registry.http.interval") final Duration retryInterval,
                             @Value("${pipe.bootstrap.delay:300000}") final int additionalDelay // 5 minutes extra to allow all nodes to reset
     ) {
         this.provider = provider;
         this.pipe = pipe;
         this.controller = controller;
         this.corruptionManager = corruptionManager;
-        this.bootstrapDelayMs = Duration.parse("PT" + retryInterval).toMillis() + additionalDelay;
+        this.bootstrapDelayMs = retryInterval.toMillis() + additionalDelay;
     }
 
     public void bootstrap(BootstrapType bootstrapType) throws Exception {

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -24,14 +24,14 @@ public class BootstrapService {
                             @Named("pipe") final Bootstrapable pipe,
                             @Named("controller") final Bootstrapable controller,
                             @Named("corruptionManager") Resetable corruptionManager,
-                            @Property(name = "registry.http.interval") final String retryInterval,
+                            @Property(name = "registry.http.interval") final Duration retryInterval,
                             @Value("${pipe.bootstrap.delay:300000}") final int additionalDelay // 5 minutes extra to allow all nodes to reset
     ) {
         this.provider = provider;
         this.pipe = pipe;
         this.controller = controller;
         this.corruptionManager = corruptionManager;
-        this.bootstrapDelayMs = Duration.parse("PT" + retryInterval).toMillis() + additionalDelay;
+        this.bootstrapDelayMs = retryInterval.toMillis() + additionalDelay;
     }
 
     public void bootstrap(BootstrapType bootstrapType) throws Exception {

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -4,6 +4,7 @@ import com.tesco.aqueduct.registry.model.BootstrapType;
 import com.tesco.aqueduct.registry.model.Bootstrapable;
 import com.tesco.aqueduct.registry.model.Resetable;
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -11,6 +12,7 @@ import jakarta.inject.Singleton;
 import java.time.Duration;
 
 @Singleton
+@Requires(property = "registry.http.interval")
 public class BootstrapService {
     private final Bootstrapable provider;
     private final Bootstrapable pipe;

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -1,0 +1,86 @@
+package com.tesco.aqueduct.registry.client;
+
+import com.tesco.aqueduct.registry.model.BootstrapType;
+import com.tesco.aqueduct.registry.model.Bootstrapable;
+import com.tesco.aqueduct.registry.model.Resetable;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.time.Duration;
+
+@Singleton
+public class BootstrapService {
+    private final Bootstrapable provider;
+    private final Bootstrapable pipe;
+    private final Bootstrapable controller;
+    private final Resetable corruptionManager;
+    private final long bootstrapDelayMs;
+
+    public BootstrapService(@Named("provider") final Bootstrapable provider,
+                            @Named("pipe") final Bootstrapable pipe,
+                            @Named("controller") final Bootstrapable controller,
+                            @Named("corruptionManager") Resetable corruptionManager,
+                            @Property(name = "registry.http.interval") String retryInterval,
+                            @Value("${pipe.bootstrap.delay:300000}") final int additionalDelay // 5 minutes extra to allow all nodes to reset
+    ) {
+        this.provider = provider;
+        this.pipe = pipe;
+        this.controller = controller;
+        this.corruptionManager = corruptionManager;
+        this.bootstrapDelayMs = Duration.parse("PT" + retryInterval).toMillis() + additionalDelay;
+    }
+
+    public void bootstrap(BootstrapType bootstrapType) throws Exception {
+        switch (bootstrapType) {
+            case PROVIDER:
+                provider.stop();
+                provider.reset();
+                provider.start();
+                break;
+            case PIPE_AND_PROVIDER:
+                provider.stop();
+                provider.reset();
+                pipe.stop();
+                controller.stop();
+                pipe.reset();
+                pipe.start();
+                controller.start();
+                provider.start();
+                break;
+            case PIPE:
+                pipe.stop();
+                controller.stop();
+                pipe.reset();
+                pipe.start();
+                controller.start();
+                break;
+            case PIPE_WITH_DELAY:
+                pipe.stop();
+                controller.stop();
+                pipe.reset();
+                Thread.sleep(bootstrapDelayMs);
+                pipe.start();
+                controller.start();
+                break;
+            case PIPE_AND_PROVIDER_WITH_DELAY:
+                provider.stop();
+                provider.reset();
+                pipe.stop();
+                controller.stop();
+                pipe.reset();
+                Thread.sleep(bootstrapDelayMs);
+                pipe.start();
+                controller.start();
+                provider.start();
+                break;
+            case CORRUPTION_RECOVERY:
+                provider.stop();
+                provider.reset();
+                pipe.stop();
+                corruptionManager.reset();
+                break;
+        }
+    }
+}

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/RegistryClient.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/RegistryClient.java
@@ -14,5 +14,5 @@ public interface RegistryClient {
     @CircuitBreaker(delay = "${registry.http.client.delay}", attempts = "${registry.http.client.attempts}", reset = "${registry.http.client.reset}")
     @Post(uri = "/registry")
     @Header(name="Accept-Encoding", value="gzip, deflate")
-    RegistryResponse register(@Body Node node);
+    RegistryResponse registerAndConsumeBootstrapRequest(@Body Node node);
 }

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/SelfRegistrationTask.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/SelfRegistrationTask.java
@@ -1,21 +1,14 @@
 package com.tesco.aqueduct.registry.client;
 
-import com.tesco.aqueduct.registry.model.Bootstrapable;
 import com.tesco.aqueduct.registry.model.Node;
 import com.tesco.aqueduct.registry.model.RegistryResponse;
-import com.tesco.aqueduct.registry.model.Resetable;
 import com.tesco.aqueduct.registry.utils.RegistryLogger;
 import io.micronaut.context.annotation.Context;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
 
 @Context
 @Requires(property = "registry.http.interval")
@@ -25,32 +18,19 @@ public class SelfRegistrationTask {
     private final RegistryClient client;
     private final SummarySupplier selfSummary;
     private final ServiceList services;
-    private final Bootstrapable provider;
-    private final Bootstrapable pipe;
-    private final Bootstrapable controller;
-    private final Resetable corruptionManager;
-    private final long bootstrapDelayMs;
+    private final BootstrapService bootstrapService;
 
     @Inject
     public SelfRegistrationTask(
         final RegistryClient client,
         final SummarySupplier selfSummary,
         final ServiceList services,
-        @Named("provider") final Bootstrapable provider,
-        @Named("pipe") final Bootstrapable pipe,
-        @Named("controller") final Bootstrapable controller,
-        @Named("corruptionManager") Resetable corruptionManager,
-        @Property(name = "registry.http.interval") String retryInterval,
-        @Value("${pipe.bootstrap.delay:300000}") final int additionalDelay // 5 minutes extra to allow all nodes to reset
+        final BootstrapService bootstrapService
     ) {
         this.client = client;
         this.selfSummary = selfSummary;
         this.services = services;
-        this.provider = provider;
-        this.pipe = pipe;
-        this.controller = controller;
-        this.corruptionManager = corruptionManager;
-        this.bootstrapDelayMs = Duration.parse("PT" + retryInterval).toMillis() + additionalDelay;
+        this.bootstrapService = bootstrapService;
     }
 
     @Scheduled(fixedRate = "${registry.http.interval}")
@@ -63,55 +43,7 @@ public class SelfRegistrationTask {
                 return;
             }
             services.update(registryResponse.getRequestedToFollow());
-            switch (registryResponse.getBootstrapType()) {
-                case PROVIDER:
-                    provider.stop();
-                    provider.reset();
-                    provider.start();
-                    break;
-                case PIPE_AND_PROVIDER:
-                    provider.stop();
-                    provider.reset();
-                    pipe.stop();
-                    controller.stop();
-                    pipe.reset();
-                    pipe.start();
-                    controller.start();
-                    provider.start();
-                    break;
-                case PIPE:
-                    pipe.stop();
-                    controller.stop();
-                    pipe.reset();
-                    pipe.start();
-                    controller.start();
-                    break;
-                case PIPE_WITH_DELAY:
-                    pipe.stop();
-                    controller.stop();
-                    pipe.reset();
-                    Thread.sleep(bootstrapDelayMs);
-                    pipe.start();
-                    controller.start();
-                    break;
-                case PIPE_AND_PROVIDER_WITH_DELAY:
-                    provider.stop();
-                    provider.reset();
-                    pipe.stop();
-                    controller.stop();
-                    pipe.reset();
-                    Thread.sleep(bootstrapDelayMs);
-                    pipe.start();
-                    controller.start();
-                    provider.start();
-                    break;
-                case CORRUPTION_RECOVERY:
-                    provider.stop();
-                    provider.reset();
-                    pipe.stop();
-                    corruptionManager.reset();
-                    break;
-            }
+            bootstrapService.bootstrap(registryResponse.getBootstrapType());
         } catch (HttpClientResponseException hcre) {
             LOG.error("SelfRegistrationTask.register", "Register error [HttpClientResponseException]: %s", hcre.getMessage());
         } catch (Exception e) {

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
@@ -1,9 +1,10 @@
 package com.tesco.aqueduct.registry.client
 
-
 import com.tesco.aqueduct.registry.model.BootstrapType
 import com.tesco.aqueduct.registry.model.Bootstrapable
 import com.tesco.aqueduct.registry.model.Resetable
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -15,7 +16,19 @@ class BootstrapServiceSpec extends Specification {
     BootstrapService bootstrapService
 
     void setup() {
-        bootstrapService = new BootstrapService(provider, pipe, controller, corruptionManager, "0.001S", 1)
+        def context = ApplicationContext
+            .builder()
+            .properties(
+                "registry.http.interval": "PT0.001S",
+                "pipe.bootstrap.delay": "1"
+            )
+            .build()
+            .registerSingleton(Bootstrapable.class, provider, Qualifiers.byName("provider"))
+            .registerSingleton(Bootstrapable.class, pipe, Qualifiers.byName("pipe"))
+            .registerSingleton(Bootstrapable.class, controller, Qualifiers.byName("controller"))
+            .registerSingleton(Resetable.class, corruptionManager, Qualifiers.byName("corruptionManager"))
+            .start()
+        bootstrapService = context.getBean(BootstrapService)
     }
 
     @Unroll

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
@@ -1,0 +1,63 @@
+package com.tesco.aqueduct.registry.client
+
+
+import com.tesco.aqueduct.registry.model.BootstrapType
+import com.tesco.aqueduct.registry.model.Bootstrapable
+import com.tesco.aqueduct.registry.model.Resetable
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BootstrapServiceSpec extends Specification {
+    def provider = Mock(Bootstrapable)
+    def pipe = Mock(Bootstrapable)
+    def controller = Mock(Bootstrapable)
+    def corruptionManager = Mock(Resetable)
+    BootstrapService bootstrapService
+
+    void setup() {
+        bootstrapService = new BootstrapService(provider, pipe, controller, corruptionManager, "0.001S", 1)
+    }
+
+    @Unroll
+    def 'bootstrap related methods are called in correct combo and order depending on bootstrap type'() {
+        when:
+        bootstrapService.bootstrap(bootstrapType)
+
+        then: "provider is stopped"
+        providerStopAndResetCalls * provider.stop()
+
+        then: "provider is reset"
+        providerStopAndResetCalls * provider.reset()
+
+        then: "pipe is stopped"
+        pipeStopCalls * pipe.stop()
+
+        then: "controller is stopped"
+        controllerStopAndStartCalls * controller.stop()
+
+        then: "corruption manager is reset"
+        corruptionManagerCalls * corruptionManager.reset()
+
+        then: "pipe is reset"
+        pipeResetAndStartCalls * pipe.reset()
+
+        then: "pipe is started"
+        pipeResetAndStartCalls * pipe.start()
+
+        then: "controller is started"
+        controllerStopAndStartCalls * controller.start()
+
+        then: "provider is started"
+        providerStartCalls * provider.start()
+
+        where:
+        bootstrapType                              | providerStopAndResetCalls | providerStartCalls | pipeResetAndStartCalls | pipeStopCalls | controllerStopAndStartCalls | corruptionManagerCalls
+        BootstrapType.PROVIDER                     | 1                         | 1                  | 0                      | 0             | 0                           | 0
+        BootstrapType.PIPE_AND_PROVIDER            | 1                         | 1                  | 1                      | 1             | 1                           | 0
+        BootstrapType.NONE                         | 0                         | 0                  | 0                      | 0             | 0                           | 0
+        BootstrapType.PIPE                         | 0                         | 0                  | 1                      | 1             | 1                           | 0
+        BootstrapType.PIPE_WITH_DELAY              | 0                         | 0                  | 1                      | 1             | 1                           | 0
+        BootstrapType.PIPE_AND_PROVIDER_WITH_DELAY | 1                         | 1                  | 1                      | 1             | 1                           | 0
+        BootstrapType.CORRUPTION_RECOVERY          | 1                         | 0                  | 0                      | 1             | 0                           | 1
+    }
+}

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
@@ -19,7 +19,7 @@ class BootstrapServiceSpec extends Specification {
         def context = ApplicationContext
             .builder()
             .properties(
-                "registry.http.interval": "PT0.001S",
+                "registry.http.interval": "0.001S",
                 "pipe.bootstrap.delay": "1"
             )
             .build()

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/BootstrapServiceSpec.groovy
@@ -19,7 +19,7 @@ class BootstrapServiceSpec extends Specification {
         def context = ApplicationContext
             .builder()
             .properties(
-                "registry.http.interval": "0.001S",
+                "registry.http.interval": "1ms",
                 "pipe.bootstrap.delay": "1"
             )
             .build()

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/SelfRegistrationTaskSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/SelfRegistrationTaskSpec.groovy
@@ -148,7 +148,7 @@ class SelfRegistrationTaskSpec extends Specification {
     }
 
     @Unroll
-    def 'bootstrap related methods are called in correct combo and order depending on bootstrap type'() {
+    def 'bootstrap service is called with the correct type'() {
         given: "a registry client"
         def registryClient = selfRegistrationTask()
 

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/SelfRegistrationTaskSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/SelfRegistrationTaskSpec.groovy
@@ -41,7 +41,7 @@ class SelfRegistrationTaskSpec extends Specification {
         then: "the client will eventually have a list of endpoints returned from the Registry Service"
         notThrown(Exception)
         ran
-        1 * upstreamClient.register(_ as Node) >> new RegistryResponse(["http://1.2.3.4", "http://5.6.7.8"], BootstrapType.NONE)
+        1 * upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> new RegistryResponse(["http://1.2.3.4", "http://5.6.7.8"], BootstrapType.NONE)
         1 * services.update(_ as List) >> { startedLatch.countDown() }
     }
 
@@ -50,7 +50,7 @@ class SelfRegistrationTaskSpec extends Specification {
         def registryClient = selfRegistrationTask()
 
         and: "when called, upstreamClient will throw an exception"
-        upstreamClient.register(_ as Node) >> { throw new RuntimeException() }
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> { throw new RuntimeException() }
 
         when: "register() is called"
         registryClient.register()
@@ -62,7 +62,7 @@ class SelfRegistrationTaskSpec extends Specification {
     def 'check register does not default to cloud pipe if previously it succeeded'() {
         given: "a registry client"
         def registryClient = selfRegistrationTask()
-        upstreamClient.register(_ as Node) >> new RegistryResponse(["http://1.2.3.4", "http://5.6.7.8"], BootstrapType.NONE) >> { throw new RuntimeException() }
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> new RegistryResponse(["http://1.2.3.4", "http://5.6.7.8"], BootstrapType.NONE) >> { throw new RuntimeException() }
 
         when: "register() is called successfully"
         registryClient.register()
@@ -79,7 +79,7 @@ class SelfRegistrationTaskSpec extends Specification {
         def registryClient = selfRegistrationTask()
 
         and: "upstream client will return null"
-        upstreamClient.register(_ as Node) >> { null }
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> { null }
 
         when: "register() is called"
         registryClient.register()
@@ -88,15 +88,68 @@ class SelfRegistrationTaskSpec extends Specification {
         0 * services.update(_)
     }
 
+    def 'till bootstraps in pipe and provider if it is stale'() {
+        given: 'the node last registered 30+ days ago'
+        def staleNode = MY_NODE.toBuilder()
+            .lastRegistrationTime(ZonedDateTime.now().minusDays(30))
+            .build()
+
+        and: "registry response without bootstrap request"
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> new RegistryResponse([], BootstrapType.NONE)
+
+        and: 'a self registration task'
+        def selfRegistrationTask = new SelfRegistrationTask(
+            upstreamClient,
+            { staleNode },
+            services,
+            bootstrapService
+        )
+
+        when:
+        selfRegistrationTask.register()
+
+        then:
+        1 * services.update([])
+
+        then:
+        1 * bootstrapService.bootstrap(BootstrapType.PIPE_AND_PROVIDER)
+    }
+
+    def 'till does not bootstrap if it is not stale'() {
+        given: 'the node last registered < 30 days ago'
+        def staleNode = MY_NODE.toBuilder()
+            .lastRegistrationTime(ZonedDateTime.now().minusDays(29))
+            .build()
+
+        and: "registry response without bootstrap request"
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> new RegistryResponse([], BootstrapType.NONE)
+
+        and: 'a self registration task'
+        def selfRegistrationTask = new SelfRegistrationTask(
+            upstreamClient,
+            { staleNode },
+            services,
+            bootstrapService
+        )
+
+        when:
+        selfRegistrationTask.register()
+
+        then:
+        1 * services.update([])
+
+        then:
+        0 * bootstrapService.bootstrap(BootstrapType.PIPE_AND_PROVIDER)
+        1 * bootstrapService.bootstrap(BootstrapType.NONE)
+    }
+
     @Unroll
     def 'bootstrap related methods are called in correct combo and order depending on bootstrap type'() {
-        def startedLatch = new CountDownLatch(1)
-
         given: "a registry client"
         def registryClient = selfRegistrationTask()
 
         and: "registry response with a bootstrap request"
-        upstreamClient.register(_ as Node) >> new RegistryResponse([], bootstrapType)
+        upstreamClient.registerAndConsumeBootstrapRequest(_ as Node) >> new RegistryResponse([], bootstrapType)
 
         when: "register() is called"
         registryClient.register()
@@ -116,9 +169,11 @@ class SelfRegistrationTaskSpec extends Specification {
     }
 
     SelfRegistrationTask selfRegistrationTask() {
-        return new SelfRegistrationTask(upstreamClient,
+        return new SelfRegistrationTask(
+            upstreamClient,
             { MY_NODE },
             services,
-            bootstrapService)
+            bootstrapService
+        )
     }
 }


### PR DESCRIPTION
# What
When a till comes online after 30 days (configurable), it is automatically bootstrapped in pipe and provider mode.

# Why
Tills become stale when they are offline for a long period of time. The messages that contain deletions are compacted that are more than 30 days old. But if a till is offline, then it will miss those deletion messages as they were compacted, resulting in a potential mismatch of an earlier message for the same key, type. The effect of this is that the till has inconsistent offset sum and it is hard to ensure it is in correct state.

# How
The till registers with cloud periodically and receives bootstrap requests in the response. We just added a check for staleness based on last registration done by the till and if it is found to be stale, it is bootstrapped.

# Pairs
@ankurj77 @williampowellTW 