### PR TITLE
Removing unnecessary stale device log message

### DIFF
--- a/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgresSQLNodeRequestStorageIntegrationSpec.groovy
+++ b/registry-http-server/src/integration/groovy/com/tesco/aqueduct/registry/postgres/PostgresSQLNodeRequestStorageIntegrationSpec.groovy
@@ -135,32 +135,4 @@ class PostgresSQLNodeRequestStorageIntegrationSpec extends Specification {
         then: "bootstrap is not returned"
         response == BootstrapType.NONE
     }
-
-    @Unroll
-    def "#comment"() {
-        given: "a node with last registration time"
-        def node = Node.builder()
-            .localUrl(new URL("http://test_node_1"))
-            .lastRegistrationTime(lastRegistrationTime)
-            .build()
-
-        when: "we check if it requires a bootstrap"
-        def bootstrapType = nodeRequestStorage.requiresBootstrap(node)
-
-        then: "bootstrap type is none"
-        bootstrapType == BootstrapType.NONE
-
-        and: "count of stale devices log is consistent with expectation"
-        TestAppender.getEvents().stream()
-        .filter {
-            it.loggerName.contains("PostgreSQLNodeRequestStorage")
-            && it.message.contains("stale device")
-        }.count() == expectedLogCount
-
-        where:
-        lastRegistrationTime              | comment                                                          | expectedLogCount
-        ZonedDateTime.now().minusDays(31) | "Node offline for more than 30 days receives bootstrap"          | 1
-        ZonedDateTime.now().minusDays(29) | "Node offline for less than 30 days does not receive bootstrap"  | 0
-        null                              | "Node with no last registration time does not receive bootstrap" | 0
-    }
 }

--- a/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRequestStorage.java
+++ b/registry-http-server/src/main/java/com/tesco/aqueduct/registry/postgres/PostgreSQLNodeRequestStorage.java
@@ -53,12 +53,6 @@ public class PostgreSQLNodeRequestStorage implements NodeRequestStorage {
 
     @Override
     public BootstrapType requiresBootstrap(Node node) throws SQLException {
-
-        if(node.getLastRegistrationTime() != null
-            && node.getLastRegistrationTime().isBefore(ZonedDateTime.now().minusDays(30))) {
-            LOG.info("requiresBootstrap", node.getHost() + " stale device");
-        }
-
         try (Connection connection = getConnection()) {
             BootstrapType bootstrapType = readBootstrapType(node.getHost(), connection);
             if (bootstrapType != BootstrapType.NONE) {


### PR DESCRIPTION
## What
Removed the unnecessary stale till log message

## Why
Earlier the log message was used to report it in splunk dashboard for potential bootstrap. Now the till is automatically bootstrapped when it is found to be stale.

## How
The check was done in the cloud registry server and has been removed.

## Pairs
@ashish-sharma09  @ankurj77 