### PR TITLE
Increase performance client permissions

### DIFF
--- a/pipe-http-server-cloud/src/main/resources/application-ppe.yml
+++ b/pipe-http-server-cloud/src/main/resources/application-ppe.yml
@@ -21,6 +21,7 @@ authentication:
         clientId: "${PERFORMANCE_TEST_CLIENT_UID}"
         roles:
           - PIPE_READ
+          - REGISTRY_WRITE
       nodeC:
         clientId: "${NODE_C_CLIENT_UID}"
         roles:

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -3,17 +3,22 @@ package com.tesco.aqueduct.registry.client;
 import com.tesco.aqueduct.registry.model.BootstrapType;
 import com.tesco.aqueduct.registry.model.Bootstrapable;
 import com.tesco.aqueduct.registry.model.Resetable;
+import com.tesco.aqueduct.registry.utils.RegistryLogger;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 
 @Singleton
 @Requires(property = "registry.http.interval")
 public class BootstrapService {
+
+    private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(BootstrapService.class));
+
     private final Bootstrapable provider;
     private final Bootstrapable pipe;
     private final Bootstrapable controller;
@@ -35,6 +40,8 @@ public class BootstrapService {
     }
 
     public void bootstrap(BootstrapType bootstrapType) throws Exception {
+        LOG.info("bootstrap", "Bootstrapping in " + bootstrapType + " mode");
+
         switch (bootstrapType) {
             case PROVIDER:
                 provider.stop();

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/BootstrapService.java
@@ -3,22 +3,17 @@ package com.tesco.aqueduct.registry.client;
 import com.tesco.aqueduct.registry.model.BootstrapType;
 import com.tesco.aqueduct.registry.model.Bootstrapable;
 import com.tesco.aqueduct.registry.model.Resetable;
-import com.tesco.aqueduct.registry.utils.RegistryLogger;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 
 @Singleton
 @Requires(property = "registry.http.interval")
 public class BootstrapService {
-
-    private static final RegistryLogger LOG = new RegistryLogger(LoggerFactory.getLogger(BootstrapService.class));
-
     private final Bootstrapable provider;
     private final Bootstrapable pipe;
     private final Bootstrapable controller;
@@ -40,8 +35,6 @@ public class BootstrapService {
     }
 
     public void bootstrap(BootstrapType bootstrapType) throws Exception {
-        LOG.info("bootstrap", "Bootstrapping in " + bootstrapType + " mode");
-
         switch (bootstrapType) {
             case PROVIDER:
                 provider.stop();


### PR DESCRIPTION
### What

Give performance test client the permission to register a node.

### Why

Performance tests are required to register nodes to assess registering performance. The endpoint previously required the client to be authenticated but after a previous change it requires the client to have the REGISTRY_WRITE role.

### How

Add REGISTRY_WRITE role to performance test client.