### PR TITLE
integrity check after rebuild

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.parallel=true
+mavenCloudUsername=DPDTJ19y
+mavenCloudPassword=rFoVWnxmt2RpyAPOiK0jUWLJoa03qEXJQbAa9CeTdNOd
+mavenDevUsername=qKoSSRd7
+mavenDevPassword=e48K6ZaDfmQkdW0FErPwKgxvr2ov9N6TOy29upF3+KH+
+mavenUser=qKoSSRd7
+mavenPassword=e48K6ZaDfmQkdW0FErPwKgxvr2ov9N6TOy29upF3+KH+

--- a/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageSpec.groovy
+++ b/pipe-storage-sqlite/src/test/groovy/com/tesco/aqueduct/pipe/storage/sqlite/SQLiteStorageSpec.groovy
@@ -401,6 +401,60 @@ class SQLiteStorageSpec extends Specification {
         !result
     }
 
+    def "integrity check returns false if result is not OK"() {
+        given: "mocked datasource"
+        dataSource = Mock(DataSource)
+        def connection = Mock(Connection)
+        dataSource.getConnection() >> connection
+
+        and: "a mocked prepared statement"
+        def preparedStatement = Mock(PreparedStatement)
+        connection.prepareStatement(*_) >> preparedStatement
+
+        and: "an SQLite storage"
+        sqliteStorage = new SQLiteStorage(dataSource, LIMIT, 10, BATCH_SIZE)
+
+        and: "an 'ok' result"
+        connection.prepareStatement(SQLiteQueries.QUICK_INTEGRITY_CHECK) >> preparedStatement
+        def resultSet = Mock(ResultSet)
+        preparedStatement.executeQuery() >> resultSet
+        resultSet.getString(1) >> "NOT_OK"
+
+        when: "run integrity check"
+        def result = sqliteStorage.runVisibilityCheck();
+
+        then:
+        sqliteStorage.isIntegrityCheckPassed(connection)==false
+        !result
+    }
+
+    def "integrity check returns true if result is not OK"() {
+        given: "mocked datasource"
+        dataSource = Mock(DataSource)
+        def connection = Mock(Connection)
+        dataSource.getConnection() >> connection
+
+        and: "a mocked prepared statement"
+        def preparedStatement = Mock(PreparedStatement)
+        connection.prepareStatement(*_) >> preparedStatement
+
+        and: "an SQLite storage"
+        sqliteStorage = new SQLiteStorage(dataSource, LIMIT, 10, BATCH_SIZE)
+
+        and: "an 'ok' result"
+        connection.prepareStatement(SQLiteQueries.QUICK_INTEGRITY_CHECK) >> preparedStatement
+        def resultSet = Mock(ResultSet)
+        preparedStatement.executeQuery() >> resultSet
+        resultSet.getString(1) >> "Ok"
+
+        when: "run integrity check"
+        def result = sqliteStorage.runVisibilityCheck();
+
+        then:
+        sqliteStorage.isIntegrityCheckPassed(connection)==true
+        result
+    }
+
     def "full integrity should rethrow RuntimeException on SQLException"() {
         given: "mocked datasource"
         dataSource = Mock(DataSource)


### PR DESCRIPTION
**Why:** There is not status of sql corruption recovery after auto recovery steps,so it is creating new alert even after auto recovery initiated.

What: Need status of recovery steps whether  sql corruption is recovered after auto recovery steps or not

How: Added logs to print  recovery status
