### PR TITLE
envoy-proxy-backward-compatibility

### DIFF
--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/PipeServiceInstance.java
@@ -99,6 +99,22 @@ public class PipeServiceInstance implements ServiceInstance {
         return UriBuilder.of(getURI()).path("/pipe/_status").build().toString();
     }
 
+    public boolean equals(Object instance)
+    {
+        if(instance==this)
+            return true;
+        if(instance == null || instance.getClass()!= this.getClass())
+            return false;
+        PipeServiceInstance target=(PipeServiceInstance)instance;
+        return url.equals(target.getUrl());
+    }
+
+    public int hashCode()
+    {
+        return url.hashCode();
+    }
+
+
     private URI getUriWithBasePath(final URI relativeURI) throws URISyntaxException {
         // replace() needed to make it compatible with the Windows file system
         final String path = Paths.get(url.getPath(), relativeURI.getPath()).toString().replace('\\', '/');

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
@@ -142,7 +142,7 @@ public class ServiceList {
         }
         catch (Exception e)
         {
-            LOG.error("persist", "Unable to parse url",e);
+            LOG.error("persist", "Unable to parse url",e.getMessage());
         }
         return this.cloudInstance;
     }

--- a/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
+++ b/registry-client/src/main/java/com/tesco/aqueduct/registry/client/ServiceList.java
@@ -135,7 +135,7 @@ public class ServiceList {
                 URL httpsUrl = new URL(httpUrl.replaceFirst("^http", "https"));
                 return getServiceInstance(httpsUrl);
             }
-            else if(!httpUrl.startsWith("http")) {
+            else if(httpUrl.startsWith("https")) {
                 URL httpsUrl = new URL(httpUrl.replaceFirst("^https", "http"));
                 return getServiceInstance(httpsUrl);
             }

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/PipeServiceInstanceSpec.groovy
@@ -28,6 +28,28 @@ class PipeServiceInstanceSpec extends Specification {
         "http://foo.bar"      | "/pipe/0"
     }
 
+    def "PipeServiceInstance equal method should return ture if both urls are same"() {
+        given: "A url with a base path"
+        def url = URL(baseUrl1)
+        def url2 =  URL(baseUrl2)
+        def serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), url)
+        def serviceInstance1 = new PipeServiceInstance(new DefaultHttpClient(), url2)
+
+
+        when: "resolving a relative uri"
+        def response = serviceInstance.equals(serviceInstance1)
+
+        then: "the path is returned with the base path included"
+        response == result
+
+        where:
+        baseUrl1              | baseUrl2               | result
+        "http://foo.bar/bar"  | "http://foo.bar/bar"   | true
+        "http://foo.bar/bar/" | "http://foo.bar/bar/"  | true
+        "http://foo.bar/"     | "https://foo.bar/"     | false
+        "https://foo.bar"     | "http://foo.bar"       | false
+    }
+
     def "RxClient errors are not rethrown"() {
         given: "client throwing errors"
         def serviceInstance = new PipeServiceInstance(new DefaultHttpClient(), new URL("http://not.a.url"))

--- a/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/ServiceListSpec.groovy
+++ b/registry-client/src/test/groovy/com/tesco/aqueduct/registry/client/ServiceListSpec.groovy
@@ -52,6 +52,44 @@ class ServiceListSpec extends Specification {
         serviceList.stream().map({ p -> p.getUrl()}).collect() == list
     }
 
+    def "envoy proxy backward compatibility if the publisher pipe url is https and provider pipe url is http "() {
+        given: "a service list"
+        URL PROVIDER_PIPE_URL = URL("http://a1")
+        URL PUBLISHER_PIPE_URL = URL("https://a1")
+
+        PipeServiceInstance cloudServiceInstance = new PipeServiceInstance(new DefaultHttpClient(), PROVIDER_PIPE_URL)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), cloudServiceInstance, existingPropertiesFile)
+
+        and: "the service list has been updated before"
+        serviceList.update([URL_2,PUBLISHER_PIPE_URL])
+
+        when: "service list is updated with a new list"
+        def list = [URL_2,PROVIDER_PIPE_URL]
+        serviceList.update(list)
+
+        then: "list returned matches updated list"
+        serviceList.stream().map({ p -> p.getUrl()}).collect() == list
+    }
+
+    def "envoy proxy backward compatibility if the publisher pipe url is http and provider pipe url is http "() {
+        given: "a service list"
+        URL PROVIDER_PIPE_URL = URL("https://a1")
+        URL PUBLISHER_PIPE_URL = URL("https://a1")
+
+        PipeServiceInstance cloudServiceInstance = new PipeServiceInstance(new DefaultHttpClient(), PROVIDER_PIPE_URL)
+        ServiceList serviceList = new ServiceList(new DefaultHttpClient(), cloudServiceInstance, existingPropertiesFile)
+
+        and: "the service list has been updated before"
+        serviceList.update([URL_2,PUBLISHER_PIPE_URL])
+
+        when: "service list is updated with a new list"
+        def list = [URL_2,PROVIDER_PIPE_URL]
+        serviceList.update(list)
+
+        then: "list returned matches updated list"
+        serviceList.stream().map({ p -> p.getUrl()}).collect() == list
+    }
+
     def "when services are updated, previous services keep their status"() {
         given: "a service list"
         ServiceList serviceList = new ServiceList(new DefaultHttpClient(), serviceInstance, existingPropertiesFile) {


### PR DESCRIPTION
**Why :** If the pipe URL has configured with https then it will not work for the versions with envoy proxy because envoy proxy only works with http URLs where as URL should be https for old versions without envoy proxy.

**How:** Comparing both pipe url configured at provider and publisher, if both are not equal , then we are replacing pipe url with provider cloud pipe url. 
1. With envoy proxy changes : 
         pipe url at  publisher is : https://xxx.tesco.com
         pipe url at  provider is : http://xxx.tesco.com
  both are different, so we are going to replace "https://xxx.tesco.com" with "http://xxx.tesco.com"

1. Without  envoy proxy changes : 
         pipe url at  publisher is : https://xxx.tesco.com
         pipe url at  provider is : https://xxx.tesco.com
  both are same, so we are not changing any thing here.
